### PR TITLE
Added thispath to params when formatting error messages

### DIFF
--- a/lib/util/validation-error.js
+++ b/lib/util/validation-error.js
@@ -44,9 +44,9 @@ ValidationError.formatError = function (message, params) {
 
   var fn = function fn(_ref) {
     var path = _ref.path;
-    var params = babelHelpers.objectWithoutProperties(_ref, ['path']);
+    var params = babelHelpers.objectWithoutProperties(_ref, []);
 
-    params.path = 'this' + (path ? path.charAt(0) === '[' ? path : '.' + path : '');
+    params.thispath = 'this' + (path ? path.charAt(0) === '[' ? path : '.' + path : '');
 
     return message(params);
   };

--- a/src/util/validation-error.js
+++ b/src/util/validation-error.js
@@ -36,6 +36,7 @@ ValidationError.formatError = function(message, params) {
     message = replace(message)
 
   let fn = ({ path, ...params }) => {
+    params.rawpath = path
     params.path =  'this' + (path 
       ? (path.charAt(0) === '[' ? path : '.' + path) 
       : '')


### PR DESCRIPTION
Additionally, path is no longer prefixed with 'this'. To keep things exactly as they were, it would be necessary you would need to change the locale.js file, which I left alone because I wanted to get rid of the prefix.