### PR TITLE
Pass the path when rejecting a field based on type

### DIFF
--- a/lib/mixed.js
+++ b/lib/mixed.js
@@ -113,7 +113,7 @@ SchemaType.prototype = {
 
     var errors = [];
     var reject = function reject() {
-      return Promise.reject(new ValidationError(errors, value));
+      return Promise.reject(new ValidationError(errors, value, path));
     };
 
     if (!state.isCast && !isStrict) value = schema._cast(value, options);

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -108,7 +108,7 @@ SchemaType.prototype = {
     let path = state.path
 
     let errors = [];
-    let reject = () => Promise.reject(new ValidationError(errors, value));
+    let reject = () => Promise.reject(new ValidationError(errors, value, path));
 
     if ( !state.isCast && !isStrict )
       value = schema._cast(value, options)


### PR DESCRIPTION
Hey there!

I'm using yup to validate form inputs and then display errors if they are incorrect.

I was having a little bit of trouble validating ```number()``` ```typeError()```s and grabbing the path of the incorrect input.

After a bit of digging around, it seems that if you add the path to the reject method it becomes available when dealing with validation errors, which is super useful!

Cheers,
~ Simon