### PR TITLE
faster implementation of the BadSet class, tests for the BadSet class

### DIFF
--- a/src/util/set.js
+++ b/src/util/set.js
@@ -1,43 +1,30 @@
-var toString = Object.prototype.toString
-var isDate = obj => toString.call(obj) === '[object Date]'
-
-module.exports =  class BadSet {
+module.exports = class BadSet {
 
   constructor(){
-    this._array = []
-    this.length = 0
+    this._map = {}
   }
 
   values(){
-    return this._array
+    return Object.keys(this._map).map(v => this._map[v])
   }
 
-  add(item) {
-    if(!this.has(item)) 
-      this._array.push(item)
+  get length(){
+    return Object.keys(this._map).length
+  }
 
-    this.length = this._array.length
+  add(item){
+    this._map[stringify(item)] = item
   }
 
   delete(item){
-    var idx = indexOf(this._array, item)
-    if( idx !== -1) 
-      this._array.splice(idx, 1)
-
-    this.length = this._array.length
+    delete this._map[stringify(item)]
   }
 
-  has(val){
-    return indexOf(this._array, val) !== -1
+  has(item){
+    return this._map.hasOwnProperty(stringify(item))
   }
 }
 
-
-function indexOf(arr, val){
-  for (var i = 0; i < arr.length; i++) {
-    var item = arr[i]
-    if (item === val || (isDate(item) && +val === +item)) 
-      return i
-  }
-  return -1
+function stringify(item){
+  return JSON.stringify(item)
 }

--- a/src/util/set.js
+++ b/src/util/set.js
@@ -1,7 +1,9 @@
+var hasOwnProperty = Object.prototype.hasOwnProperty
+
 module.exports = class BadSet {
 
   constructor(){
-    this._map = {}
+    this._map = Object.create(null)
   }
 
   values(){
@@ -21,7 +23,7 @@ module.exports = class BadSet {
   }
 
   has(item){
-    return this._map.hasOwnProperty(stringify(item))
+    return hasOwnProperty.call(this._map, stringify(item))
   }
 }
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -58,14 +58,14 @@ describe( 'Mixed Types ', function(){
   })
 
   it('should limit values', function(){
-    var inst = mixed().oneOf(['hello', 5])
+    var inst = mixed().oneOf([5, 'hello'])
 
     return Promise.all([
       inst.isValid(5).should.eventually.equal(true),
       inst.isValid('hello').should.eventually.equal(true),
 
       inst.validate(6).should.be.rejected.then(function(err) {
-        err.errors[0].should.equal('this must be one the following values: hello, 5')
+        err.errors[0].should.equal('this must be one the following values: 5, hello')
       })
     ])
   })
@@ -85,7 +85,7 @@ describe( 'Mixed Types ', function(){
   })
 
   it('should exclude values', function(){
-    var inst = mixed().notOneOf(['hello', 5])
+    var inst = mixed().notOneOf([5, 'hello'])
 
     return Promise.all([
       inst.isValid(6).should.eventually.equal(true),
@@ -94,7 +94,7 @@ describe( 'Mixed Types ', function(){
       inst.isValid(5).should.eventually.equal(false),
 
       inst.validate(5).should.be.rejected.then(function(err){
-        err.errors[0].should.equal('this must not be one the following values: hello, 5')
+        err.errors[0].should.equal('this must not be one the following values: 5, hello')
       }),
       inst.oneOf([5]).isValid(5).should.eventually.equal(true)
     ])

--- a/test/yup.js
+++ b/test/yup.js
@@ -4,6 +4,7 @@ var Promise = require('promise/src/es6-extensions')
   , chai  = require('chai')
   , chaiAsPromised = require('chai-as-promised')
   , reach = require('../src/util/reach')
+  , BadSet = require('../src/util/set')
   , number = require('../src/number')
   , array = require('../src/array')
   , object = require('../src/object')
@@ -84,7 +85,134 @@ describe('Yup', function(){
     })
   })
 
+  describe('BadSet', function(){
+    it('should preserve primitive types', function(){
+      var set = new BadSet()
 
+      set.add(2)
+      set.has(2).should.be.true
+      set.has('2').should.be.false
+      set.values().should.eql([2])
+
+      set.add('3')
+      set.has('3').should.be.true
+      set.has(3).should.be.false
+      set.values().should.eql([2, '3'])
+
+      set.add(false)
+      set.has(false).should.be.true
+      set.has('false').should.be.false
+      set.values().should.eql([2, '3', false])
+
+      set.add('true')
+      set.has('true').should.be.true
+      set.has(true).should.be.false
+      set.values().should.eql([2, '3', false, 'true'])
+
+      set.add(null)
+      set.has(null).should.be.true
+      set.has('null').should.be.false
+      set.values().should.eql([2, '3', false, 'true', null])
+
+      set.add(undefined)
+      set.has(undefined).should.be.true
+      set.has('undefined').should.be.false
+      set.values().should.eql([2, '3', false, 'true', null, undefined])
+    })
+
+    it('should perform value equality for arrays and objects', function(){
+      var set = new BadSet()
+
+      var oneTwoThree = [1, '2', 3]
+      set.add(oneTwoThree)
+      set.has(oneTwoThree).should.be.true
+      set.has([1, '2', 3]).should.be.true
+      set.values().should.eql([[1, '2', 3]])
+      set.length.should.equal(1)
+
+      set.add([1, '2', 3])
+      set.has(oneTwoThree).should.be.true
+      set.has([1, '2', 3]).should.be.true
+      set.values().should.eql([[1, '2', 3]])
+      set.length.should.equal(1)
+
+      var aOnebTwo = { a: 1, b: '2'}
+      set.add(aOnebTwo)
+      set.has(aOnebTwo).should.be.true
+      set.has({ a: 1, b: '2'}).should.be.true
+      set.values().should.eql([[1, '2', 3], { a: 1, b: '2'}])
+      set.length.should.equal(2)
+
+      set.add({ a: 1, b: '2'})
+      set.has(aOnebTwo).should.be.true
+      set.has({ a: 1, b: '2'}).should.be.true
+      set.values().should.eql([[1, '2', 3], { a: 1, b: '2'}])
+      set.length.should.equal(2)
+    })
+
+    it('should perform value equality for dates', function(){
+      var set = new BadSet()
+
+      var someDate = new Date('12-12-12')
+      set.add(someDate)
+      set.has(someDate).should.be.true
+      set.has(new Date('12-12-12')).should.be.true
+      set.values().should.eql([new Date('12-12-12')])
+      set.length.should.equal(1)
+
+      set.add(new Date('12-12-12'))
+      set.has(someDate).should.be.true
+      set.has(new Date('12-12-12')).should.be.true
+      set.values().should.eql([new Date('12-12-12')])
+      set.length.should.equal(1)
+    })
+
+    it('should not contain the same value twice', function(){
+      var set = new BadSet()
+
+      var arrayWithDuplicates = [
+        1,
+        2,
+        3,
+        '2',
+        3,
+        'abc',
+        new Date('12-12-12'),
+        4,
+        new Date('12-12-12')
+      ]
+
+      arrayWithDuplicates.forEach(item => set.add(item))
+      set.values().sort().should.eql(
+        [1, 2, 3, '2', 'abc', new Date('12-12-12'), 4].sort())
+    })
+
+    it('should delete values', function(){
+      var set = new BadSet()
+
+      set.add(2)
+      set.has(2).should.be.true
+      set.length.should.equal(1)
+      set.values().should.eql([2])
+
+      set.delete('2')
+      set.has(2).should.be.true
+      set.length.should.equal(1)
+      set.values().should.eql([2])
+
+      set.add('3')
+      set.has(2).should.be.true
+      set.has('3').should.be.true
+      set.length.should.equal(2)
+      set.values().should.eql([2, '3'])
+
+      set.delete('3')
+      set.has(2).should.be.true
+      set.has('3').should.be.false
+      set.length.should.equal(1)
+      set.values().should.eql([2])
+    })
+  })
 
   // it.only('should REACH with conditions', function(){
   //   var num = number()


### PR DESCRIPTION
see issue #27

changes:
- added tests for the BadSet class
- reimplemented the BadSet class using an object as the underlying data structure
- changed one existing test to account for different sort order of the new implementation

notes:
- see http://jsperf.com/badset/9 for performance comparison
- the iteration order of an object is undefined in the js spec, so not all browsers do the same. thus, we can no longer rely on BadSet.prototype.values() returning the values sorted by insertion order. in my opinion this is a small price to pay for the huge speed advantage of using an object instead of an array. however, if need be i can modify this implementation to store insertion order and sort the return value of BadSet.prototype.values() before returning it. however, this comes with a performance penalty, and I don't really see any reason why the order should matter for the purposes of validation library