### PR TITLE
Fix incorrect leading-zero millisecond conversion

### DIFF
--- a/src/util/isodate.js
+++ b/src/util/isodate.js
@@ -22,7 +22,7 @@ module.exports = function parseIsoDate(date) {
     struct[3] = +struct[3] || 1;
 
     // allow arbitrary sub-second precision beyond milliseconds
-    struct[7] = struct[7] ? + (struct[7] + '00').substr(0, 3) : 0;
+    struct[7] = struct[7] ? String(struct[7]).substr(0, 3) : 0;
 
     // timestamps without timezone identifiers should be considered local time
     if ((struct[8] === undefined || struct[8] === '') && (struct[9] === undefined || struct[9] === ''))

--- a/test/date.js
+++ b/test/date.js
@@ -14,6 +14,10 @@ describe('Date types', function(){
     inst.cast(new Date()).should.be.a('date')
     inst.cast('jan 15 2014').should.eql(new Date(2014, 0, 15))
     inst.cast('2014-09-23T19:25:25Z').should.eql(new Date(1411500325000))
+    // Leading-zero milliseconds
+    inst.cast('2016-08-10T11:32:19.012Z').should.eql(new Date(1470828739012))
+    // Microsecond precision
+    inst.cast('2016-08-10T11:32:19.2125Z').should.eql(new Date(1470828739212))
   })
 
   it('should return invalid date for failed casts', function(){


### PR DESCRIPTION
This fixes an issue where a leading-zero millisecond ISO string would get parsed incorrectly.

Input: `2016-08-10T11:32:19.012Z`
Parsed as: `2016-08-10T11:32:19.120Z`