### PR TITLE
Update readme to reflect abortEarly default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ The `options` argument is an object hash containing any schema options you may w
 ```js
 Options = {
   strict: boolean = false;
-  abortEarly: boolean = false;
+  abortEarly: boolean = true;
   stripUnknown: boolean = false;
   recursive: boolean = true;
   context: ?object;


### PR DESCRIPTION
`mixed#validate`'s `abortEarly` option defaults to `true`, not `false`: https://github.com/jquense/yup/blob/master/src/mixed.js#L41. This took me some time to realize because the readme documents otherwise. This PR corrects that mistake!

Thanks for the great library!