### PR TITLE
Fix string interpolation 0 issue

### DIFF
--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -2,7 +2,13 @@
 let strReg = /\$\{\s*(\w+)\s*\}/g;
 
 let replace = str =>
-  params => str.replace(strReg, (_, key) => params[key] || '')
+  params => str.replace(strReg, (_, key) => {
+    const val = params[key]
+    if (typeof val === 'number') {
+      return val
+    }
+    return val || ''
+  })
 
 
 export default function ValidationError(errors, value, field, type) {

--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -2,13 +2,7 @@
 let strReg = /\$\{\s*(\w+)\s*\}/g;
 
 let replace = str =>
-  params => str.replace(strReg, (_, key) => {
-    const val = params[key]
-    if (typeof val === 'number') {
-      return val
-    }
-    return val || ''
-  })
+  params => str.replace(strReg, (_, key) => String(params[key]))
 
 
 export default function ValidationError(errors, value, field, type) {

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -167,8 +167,10 @@ SchemaType.prototype = {
   },
 
   validate(value, options = {}, cb) {
-    if (typeof options === 'function')
-      cb = options, options = {}
+    if (typeof options === 'function') {
+      cb = options
+      options = {}
+    }
 
     let schema = this.resolve(options)
 
@@ -212,8 +214,10 @@ SchemaType.prototype = {
 
 
   isValid(value, options, cb) {
-    if (typeof options === 'function')
-      cb = options, options = {}
+    if (typeof options === 'function') {
+      cb = options
+      options = {}
+    }
 
     return nodeify(this
       .validate(value, options)

--- a/test/ValidationError.js
+++ b/test/ValidationError.js
@@ -1,0 +1,36 @@
+import ValidationError from '../src/ValidationError'
+
+describe('ValidationError', function() {
+  describe('formatError', function() {
+    it('should insert the params into the message', function() {
+      const str = ValidationError.formatError('Some message ${param}', {
+        param: 'here'
+      })
+      str.should.contain('here')
+    })
+
+    it(`should auto include any param named 'label' or 'path' as the 'path' param`, function() {
+      const str = ValidationError.formatError('${path} goes here', {
+        label: 'label'
+      })
+      str.should.contain('label')
+    })
+
+    it(`should use 'this' if a 'label' or 'path' param is not provided`, function() {
+      const str = ValidationError.formatError('${path} goes here', {})
+      str.should.contain('this')
+    })
+
+    it(`should return the validation function if only a message is provided`, function() {
+      const str = ValidationError.formatError('${path} goes here')({})
+      str.should.contain('this')
+    })
+
+    it(`should include 0 in the message if 0 is provided as a param`, function() {
+      const str = ValidationError.formatError('${path} value is ${min}', {
+        min: 0
+      })
+      str.should.contain('0')
+    })
+  })
+})

--- a/test/ValidationError.js
+++ b/test/ValidationError.js
@@ -26,6 +26,20 @@ describe('ValidationError', function() {
       str.should.contain('this')
     })
 
+    it(`should include "undefined" in the message if undefined is provided as a param`, function() {
+      const str = ValidationError.formatError('${path} value is ${min}', {
+        min: undefined
+      })
+      str.should.contain('undefined')
+    })
+
+    it(`should include "null" in the message if null is provided as a param`, function() {
+      const str = ValidationError.formatError('${path} value is ${min}', {
+        min: null
+      })
+      str.should.contain('null')
+    })
+
     it(`should include 0 in the message if 0 is provided as a param`, function() {
       const str = ValidationError.formatError('${path} value is ${min}', {
         min: 0

--- a/test/array.js
+++ b/test/array.js
@@ -70,7 +70,7 @@ describe('Array types', function(){
         .of(number())
         .concat(array())
         ._subType
-    ).to.exist
+    ).to.exist()
 
     expect(
       array()

--- a/test/date.js
+++ b/test/date.js
@@ -62,7 +62,7 @@ describe('Date types', function(){
       , valid = new Date(2014, 5, 15)
 
     ;(function(){ date().max('hello') }).should.throw(TypeError)
-    ;(function(){ date().max(ref('$foo')) }).should.not.throw
+    ;(function(){ date().max(ref('$foo')) }).should.not.throw()
 
     return Promise.all([
       date().min(min).isValid(valid).should.eventually().equal(true),
@@ -84,7 +84,7 @@ describe('Date types', function(){
       , valid = new Date(2014, 5, 15)
 
     ;(function(){ date().max('hello') }).should.throw(TypeError)
-    ;(function(){ date().max(ref('$foo')) }).should.not.throw
+    ;(function(){ date().max(ref('$foo')) }).should.not.throw()
 
     return Promise.all([
       date().max(max).isValid(valid).should.eventually().equal(true),


### PR DESCRIPTION
Fixed an issue where when using yup in the following way 
```js
yup.number().min(0, 'This field must be greater than or equal to ${min}')
```

The string replace method would interpret `0` as `false` in the string replace methods `or` statement and therefore replace with an empty string.

Added some basic test cases for `ValidationError.js` `formatError` method including one checking specifically for this `0` case.

Also fixed up a few more linter issues.