### PR TITLE
Fix Promise error when passing null as the second value to .then

### DIFF
--- a/src/util/runValidations.js
+++ b/src/util/runValidations.js
@@ -28,7 +28,7 @@ function scopeToValue(promises, value, sync) {
  */
 export function propagateErrors(endEarly, errors) {
   return endEarly
-    ? null
+    ? err => { throw err; }
     : err => {
         errors.push(err);
         return err.value;


### PR DESCRIPTION
- Passing a `null` 2nd param to `.then` is not allowed (when using Bluebird
promises, it warns you)
- Return a function instead that re-throws the error to execute the endEarly condition