### PR TITLE
dont fail when getOwnPropertyDescriptor returns undefined

### DIFF
--- a/lib/util/clone.js
+++ b/lib/util/clone.js
@@ -60,7 +60,7 @@ function clone(obj, seen) {
 
       var descriptor = Object.getOwnPropertyDescriptor(obj, key);
 
-      if (descriptor.get || descriptor.set) {
+      if (descriptor && (descriptor.get || descriptor.set)) {
         Object.defineProperty(newObj, key, descriptor);
       } else {
         newObj[key] = clone(obj[key], seen);

--- a/src/util/clone.js
+++ b/src/util/clone.js
@@ -56,7 +56,7 @@ export default function clone(obj, seen) {
 
       var descriptor = Object.getOwnPropertyDescriptor(obj, key);
 
-      if (descriptor.get || descriptor.set) {
+      if (descriptor && (descriptor.get || descriptor.set)) {
         Object.defineProperty(newObj, key, descriptor);
       }
       else {


### PR DESCRIPTION
We get the error `Can not read property 'get' of undefined`, which occurs when `getOwnPropertyDescriptor` returns `undefined`.

A similar error was [fixed](https://github.com/hapijs/hoek/commit/14113f7bc17a5850588624e8b8157df60ebc6617) in the module `hoek`.
