### PR TITLE
Support for setLocale regardless of import order

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ setLocale({
     default: 'Não é válido',
   },
   number: {
-    max: 'Deve ser maior que ${min}',
+    min: 'Deve ser maior que ${min}',
   },
 })
 
@@ -165,7 +165,7 @@ const schema = yup.object().shape({
   name: yup.string(),
   age: yup.number().min(18),
 })
-schema.validate({ name: 'jimmy', age: 'hi' })
+schema.validate({ name: 'jimmy', age: 11 })
   .catch(function(err){
     err.name   // 'ValidationError'
     err.errors // => ['Deve ser maior que 18']

--- a/src/customLocale.js
+++ b/src/customLocale.js
@@ -1,9 +1,9 @@
-let dict = {}
+import locale from './locale';
 
 export function setLocale(custom){
-  return (dict = { ...dict, ...custom })
-}
-
-export function getLocale(){
-  return dict
+  Object.keys(custom).forEach(type => {
+    Object.keys(custom[type]).forEach(method => {
+      locale[type][method] = custom[type][method]
+    })
+  })
 }

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,7 +1,4 @@
 import printValue from './util/printValue';
-import { getLocale } from './customLocale'
-
-const customLocale = getLocale()
 
 export let mixed = {
   default:   '${path} is invalid',
@@ -20,7 +17,6 @@ export let mixed = {
 
     return msg;
   },
-  ...customLocale.mixed,
 }
 
 export let string = {
@@ -34,7 +30,6 @@ export let string = {
   trim:      '${path} must be a trimmed string',
   lowercase: '${path} must be a lowercase string',
   uppercase: '${path} must be a upper case string',
-  ...customLocale.string,
 }
 
 export let number = {
@@ -43,29 +38,24 @@ export let number = {
   positive:  '${path} must be a positive number',
   negative:  '${path} must be a negative number',
   integer:   '${path} must be an integer',
-  ...customLocale.number,
 }
 
 export let date = {
   min:       '${path} field must be later than ${min}',
   max:       '${path} field must be at earlier than ${max}',
-  ...customLocale.date,
 }
 
 export let boolean = {
-  ...customLocale.boolean,
 };
 
 export let object = {
   noUnknown: '${path} field cannot have keys not specified in the object shape',
-  ...customLocale.object,
 }
 
 export let array = {
   required:  '${path} is a required field',
   min:       '${path} field must have at least ${min} items',
   max:       '${path} field must have less than ${max} items',
-  ...customLocale.array,
 }
 
 export default {

--- a/test/customLocale.js
+++ b/test/customLocale.js
@@ -1,7 +1,13 @@
-import { setLocale, getLocale } from '../src/customLocale'
+import { setLocale } from '../src/customLocale'
 
 describe('Custom locale', () => {
+  it('should get default locale', () => {
+    const locale = require('../src/locale').default
+    expect(locale.string.email).to.equal('${path} must be a valid email')
+  })
+
   it('should set a new locale', () => {
+    const locale = require('../src/locale').default
     const dict = {
       string: {
         email: 'Invalid email',
@@ -10,11 +16,11 @@ describe('Custom locale', () => {
 
     setLocale(dict)
 
-    expect(getLocale()).to.deep.equal(dict)
+    expect(locale.string.email).to.equal(dict.string.email)
   })
 
   it('should update the main locale', () => {
     const locale = require('../src/locale').default
-    expect(locale.string).to.deep.include(getLocale().string)
+    expect(locale.string.email).to.equal('Invalid email')
   })
 })


### PR DESCRIPTION
Previously, import order was important to use setLocale.
It had to import `setLocale` first, then run setLocale and import `yup`.

this pull request can set the locale via setLocale regardless of the import order.
This is also convenient when someone use it, and is also useful if someone need to load and set the user language asynchronously.