### PR TITLE
Added transform for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Options = {
   abortEarly: boolean = true;
   stripUnknown: boolean = false;
   recursive: boolean = true;
+  transform: boolean = false;
   context: ?object;
 }
 ```
@@ -361,6 +362,8 @@ than after all validations run.
 - `stripUnknown`: remove unspecified keys from objects.
 - `recursive`: when `false` validations will not descend into nested schema
 (relevant for objects or arrays).
+- `transform`: this will make validate to return the results of the validations 
+  instead of the input values. 
 - `context`: any context needed for validating schema conditions (see: `when()`)
 
 ```js

--- a/src/array.js
+++ b/src/array.js
@@ -100,7 +100,8 @@ inherits(ArraySchema, MixedSchema, {
           value,
           errors,
           endEarly,
-          validations
+          validations,
+          transform:options.transform
         })
       })
   },

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -180,6 +180,7 @@ SchemaType.prototype = {
 
     let isStrict = this._option('strict', options)
     let endEarly = this._option('abortEarly', options)
+    let transform = this._option('transform', options)
 
     let sync = options.sync
     let path = options.path
@@ -201,12 +202,13 @@ SchemaType.prototype = {
     if (this._blacklistError)
       initialTests.push(this._blacklistError(validationParams));
 
-    return runValidations({ validations: initialTests, endEarly, value, path, sync })
+    return runValidations({ validations: initialTests, endEarly, value, path, sync, transform:false })
       .then(value => runValidations({
         path,
         sync,
         value,
         endEarly,
+        transform,
         validations: this.tests.map(fn => fn(validationParams)),
       }))
   },

--- a/src/object.js
+++ b/src/object.js
@@ -173,6 +173,7 @@ inherits(ObjectSchema, MixedSchema, {
           value,
           errors,
           endEarly,
+          transform: opts.transform,
           path: opts.path,
           sort: sortByKeyOrder(this.fields)
         })

--- a/src/util/createValidation.js
+++ b/src/util/createValidation.js
@@ -1,7 +1,7 @@
 import mapValues from 'lodash/mapValues';
 import ValidationError from '../ValidationError'
 import Ref from '../Reference'
-import { SynchronousPromise } from 'synchronous-promise';
+import { SynchronousPromise } from './syncPromise';
 
 
 let formatError = ValidationError.formatError
@@ -70,6 +70,8 @@ export default function createValidation(options) {
 
         else if (!validOrError)
           throw createError()
+
+        return validOrError;
       })
   }
 

--- a/src/util/syncPromise.js
+++ b/src/util/syncPromise.js
@@ -1,0 +1,1 @@
+export {SynchronousPromise} from 'synchronous-promise';

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -3,6 +3,7 @@ import object from '../src/object';
 import string from '../src/string';
 import number from '../src/number';
 import reach from '../src/util/reach';
+import array from '../src/array';
 
 let noop = () => {}
 
@@ -576,3 +577,20 @@ describe('Mixed Types ', () => {
   })
 
 })
+
+describe('Validate transform', ()=>{
+    it('should return the validated value', ()=>{
+        const apiValidator = mixed().test('apivalidation', '', function(value){
+            // This is an api server call
+            return new Promise(r => {
+                setTimeout(()=> r(value+value), 1000)
+            });
+        });
+        return Promise.all([
+            apiValidator.validate(10, {transform:true}).should.eventually().equal(20),
+            array().of(apiValidator).validate([10, 20, 40], {transform:true}).should.become([20, 40, 80]),
+            array().of(apiValidator).validate([10, 20, 40], {transform:false}).should.become([10, 20, 40]),
+            array().of(apiValidator).validate([10, 20, 40]).should.become([10, 20, 40])
+        ])
+    })
+});


### PR DESCRIPTION
Allows validate to resolve to the results of the validations. This can be requested by adding the option `transform` to the option (see added test). 

```
        const apiValidator = mixed().test('apivalidation', '', function(value){
            // This is an api server call
            return new Promise(r => {
                setTimeout(()=> r(value+value), 1000)
            });
        });
        return Promise.all([
            apiValidator.validate(10, {transform:true}).should.eventually().equal(20),
            array().of(apiValidator).validate([10, 20, 40], {transform:true}).should.become([20, 40, 80]),
            array().of(apiValidator).validate([10, 20, 40], {transform:false}).should.become([10, 20, 40]),
            array().of(apiValidator).validate([10, 20, 40]).should.become([10, 20, 40])
        ])

```