### PR TITLE
Use parseInt instead of | operator for integer validation

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -5,7 +5,7 @@ import isAbsent from './util/isAbsent';
 
 let isNaN = value => value != +value
 
-let isInteger = val => isAbsent(val) || val === (val | 0)
+let isInteger = val => isAbsent(val) || val === parseInt(val, 10)
 
 export default function NumberSchema() {
   if (!(this instanceof NumberSchema))


### PR DESCRIPTION
Seems like the `|` operator check will return a false negative given a sufficiently large integer. This PR solves #50 