### PR TITLE
Fix hasInList when list has no refs

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -47,13 +47,10 @@ const addToList = (value, list) => {
 
 const hasInList = (value, resolve, list) => {
   if (list.has(value)) return true;
+  if (!list.refs) return false;
 
   let item;
-  let values = list.refs ? list.refs.values() : undefined;
-
-  if (!values) {
-    return false;
-  }
+  let values = list.refs.values();
 
   while (item = values.next(), !item.done) {
     if (resolve(item.value) === value)

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -48,7 +48,12 @@ const addToList = (value, list) => {
 const hasInList = (value, resolve, list) => {
   if (list.has(value)) return true;
 
-  let item; let values = list.refs.values()
+  let item;
+  let values = list.refs ? list.refs.values() : undefined;
+
+  if (!values) {
+    return false;
+  }
 
   while (item = values.next(), !item.done) {
     if (resolve(item.value) === value)


### PR DESCRIPTION
When upgrading Yup from 0.23 to 0.24 our validators ended in the following error `unknown property values from undefined` in the `hasInList` function in `mixed.js` file.

This is a quick workaround. It seems to work and does not break the tests.

Regards.