### PR TITLE
Squash bluebird promise warnings

### DIFF
--- a/src/util/runValidations.js
+++ b/src/util/runValidations.js
@@ -28,7 +28,7 @@ function scopeToValue(promises, value, sync) {
  */
 export function propagateErrors(endEarly, errors) {
   return endEarly
-    ? null
+    ? err => { throw err; }
     : err => {
         errors.push(err);
         return err.value;


### PR DESCRIPTION
About not passing in a function for error handler. Any reason not to?

This is a follow up on #89 to resolve merge conflict