### PR TITLE
Upgrade toposort dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lodash": "^4.17.0",
     "property-expr": "^1.2.0",
     "synchronous-promise": "^1.0.18",
-    "toposort": "^0.2.10",
+    "toposort": "^1.0.6",
     "type-name": "^2.0.1"
   },
   "release-script": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4238,9 +4238,9 @@ to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
 
-toposort@^0.2.10:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-0.2.12.tgz#c7d2984f3d48c217315cc32d770888b779491e81"
+toposort@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.6.tgz#c31748e55d210effc00fdcdc7d6e68d7d7bb9cec"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"


### PR DESCRIPTION
This resolves an issue with uglify where the toposort.array method gets removed from the compressed file.