### PR TITLE
Add the ability to get paths relative to a schema no rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ node_modules
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -76,3 +77,4 @@ $RECYCLE.BIN/
 
 # Ignore build files
 lib/
+.vscode/launch.json

--- a/src/Condition.js
+++ b/src/Condition.js
@@ -40,9 +40,8 @@ class Conditional {
     }
   }
 
-  getValue(parent, context) {
-    let values = this.refs.map(r => r.getValue(parent, context));
-
+  getValue(options) {
+    let values = this.refs.map(r => r.getValue(options));
     return values;
   }
 

--- a/src/Lazy.js
+++ b/src/Lazy.js
@@ -11,8 +11,8 @@ class Lazy {
     };
   }
 
-  resolve({ value, ...rest }) {
-    return this._resolve(value, rest);
+  resolve({ fieldValue, ...rest }) {
+    return this._resolve(fieldValue, rest);
   }
 
   cast(value, options) {

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -1,24 +1,11 @@
 import { getter } from 'property-expr';
-import makePath from './util/makePath';
+import { isRelativePath, default as makePath } from './util/makePath';
 
 let validateType = d => {
   if (typeof d !== 'string')
     throw new TypeError("ref's must be strings, got: " + d);
 };
-function getParentPath(path) {
-  const objectIndex = path.lastIndexOf('.');
-  return path.substring(0, objectIndex);
-}
-function getRelativePath(key, path) {
-  // remove '../' from the beginning of the key
-  key = key.slice(3);
-  path = getParentPath(path);
-  const isRelativePath = key.indexOf('../') === 0;
-  if (isRelativePath) {
-    return getRelativePath(key, path);
-  }
-  return makePath`${path}.${key}`;
-}
+
 export default class Reference {
   static isRef(value) {
     return !!(value && (value.__isYupRef || value instanceof Reference));
@@ -35,7 +22,7 @@ export default class Reference {
     this.key = key.trim();
     this.prefix = prefix;
     this.isContext = this.key.indexOf(prefix) === 0;
-    this.isRelativePath = this.key.indexOf('../') === 0;
+    this.isRelativePath = isRelativePath(this.key);
     this.path = this.isContext ? this.key.slice(this.prefix.length) : this.key;
     if (!this.isRelativePath) {
       this._get = getter(this.path, true);
@@ -54,11 +41,8 @@ export default class Reference {
     const { context, parent, value } = options;
     let refValue;
     if (this.isRelativePath) {
-      const relativePath = getRelativePath(
-        this.key,
-        getParentPath(options.path),
-      );
-      const _get = getter(relativePath, true);
+      this.path = makePath`${options.path}.${this.key}`;
+      const _get = getter(this.path, true);
       refValue = _get(value);
     } else {
       refValue = this._get(this.isContext ? context : parent || context || {});

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -1,5 +1,5 @@
 import { getter } from 'property-expr';
-import { isRelativePath, default as makePath } from './util/makePath';
+import { isRelativePath, getRelativePath } from './util/makePath';
 
 let validateType = d => {
   if (typeof d !== 'string')
@@ -41,7 +41,7 @@ export default class Reference {
     const { context, parent, value } = options;
     let refValue;
     if (this.isRelativePath) {
-      this.path = makePath`${options.path}.${this.key}`;
+      this.path = getRelativePath(options.path, this.key);
       const _get = getter(this.path, true);
       refValue = _get(value);
     } else {

--- a/src/array.js
+++ b/src/array.js
@@ -82,6 +82,7 @@ inherits(ArraySchema, MixedSchema, {
             path,
             strict: true,
             parent: value,
+            fieldValue: value[idx],
             originalValue: originalValue[idx],
           };
 

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -159,11 +159,10 @@ SchemaType.prototype = {
     return !this._typeCheck || this._typeCheck(v);
   },
 
-  resolve({ context, parent }) {
+  resolve(options) {
     if (this._conditions.length) {
       return this._conditions.reduce(
-        (schema, match) =>
-          match.resolve(schema, match.getValue(parent, context)),
+        (schema, match) => match.resolve(schema, match.getValue(options)),
         this,
       );
     }
@@ -172,6 +171,7 @@ SchemaType.prototype = {
   },
 
   cast(value, options = {}) {
+    options.value = options.value || value;
     let resolvedSchema = this.resolve(options);
     let result = resolvedSchema._cast(value, options);
 
@@ -265,11 +265,13 @@ SchemaType.prototype = {
   },
 
   validate(value, options = {}) {
+    options.value = options.value || value;
     let schema = this.resolve(options);
     return schema._validate(value, options);
   },
 
   validateSync(value, options = {}) {
+    options.value = options.value || value;
     let schema = this.resolve(options);
     let result, err;
 

--- a/src/object.js
+++ b/src/object.js
@@ -100,7 +100,7 @@ inherits(ObjectSchema, MixedSchema, {
 
           // safe to mutate since this is fired in sequence
           innerOptions.path = makePath`${options.path}.${prop}`;
-          innerOptions.value = value[prop];
+          innerOptions.fieldValue = value[prop];
 
           field = field.resolve(innerOptions);
 

--- a/src/util/createValidation.js
+++ b/src/util/createValidation.js
@@ -62,8 +62,7 @@ export default function createValidation(options) {
     ...rest
   }) {
     let parent = options.parent;
-    let resolve = value =>
-      Ref.isRef(value) ? value.getValue(parent, options.context) : value;
+    let resolve = value => (Ref.isRef(value) ? value.getValue(options) : value);
 
     let createError = createErrorFactory({
       message,

--- a/src/util/makePath.js
+++ b/src/util/makePath.js
@@ -1,6 +1,39 @@
+export const isRelativePath = path =>
+  typeof path === 'string' && path.indexOf('../') === 0;
+
+function getParentPath(path) {
+  const endsWithDot = path[path.length - 1] === '.';
+  if (endsWithDot) {
+    //remove the dot --- don't worry we add it back after removing the last path section
+    path = path.slice(0, -1);
+  }
+  let objectIndex = path.lastIndexOf('.');
+  path = path.substring(0, objectIndex);
+  if (endsWithDot) {
+    //add the dot back if it started with a dot
+    path += '.';
+  }
+  return path;
+}
+function getRelativePath(path, key) {
+  // remove '../' from the beginning of the key
+  key = key.slice(3);
+  path = getParentPath(path);
+  if (isRelativePath(key)) {
+    return getRelativePath(path, key);
+  }
+  return { path, key };
+}
 export default function makePath(strings, ...values) {
   let path = strings.reduce((str, next) => {
     let value = values.shift();
+    if (isRelativePath(value)) {
+      //relative paths using '../' always start from the parent of the current path (the object the path is in)
+      const parentPath = getParentPath(str);
+      const { path, key } = getRelativePath(parentPath, value);
+      str = path;
+      value = key;
+    }
     return str + (value == null ? '' : value) + next;
   });
 

--- a/src/util/makePath.js
+++ b/src/util/makePath.js
@@ -2,38 +2,24 @@ export const isRelativePath = path =>
   typeof path === 'string' && path.indexOf('../') === 0;
 
 function getParentPath(path) {
-  const endsWithDot = path[path.length - 1] === '.';
-  if (endsWithDot) {
-    //remove the dot --- don't worry we add it back after removing the last path section
-    path = path.slice(0, -1);
-  }
   let objectIndex = path.lastIndexOf('.');
-  path = path.substring(0, objectIndex);
-  if (endsWithDot) {
-    //add the dot back if it started with a dot
-    path += '.';
-  }
-  return path;
+  return path.substring(0, objectIndex);
 }
-function getRelativePath(path, key) {
-  // remove '../' from the beginning of the key
-  key = key.slice(3);
+export function getRelativePath(path, key) {
+  //relative paths using '../' always start from the parent of the current path (the object the path is in)
   path = getParentPath(path);
   if (isRelativePath(key)) {
+    // remove '../' from the beginning of the key
+    key = key.slice(3);
     return getRelativePath(path, key);
+  } else {
+    return makePath`${path}.${key}`;
   }
-  return { path, key };
 }
+
 export default function makePath(strings, ...values) {
   let path = strings.reduce((str, next) => {
     let value = values.shift();
-    if (isRelativePath(value)) {
-      //relative paths using '../' always start from the parent of the current path (the object the path is in)
-      const parentPath = getParentPath(str);
-      const { path, key } = getRelativePath(parentPath, value);
-      str = path;
-      value = key;
-    }
     return str + (value == null ? '' : value) + next;
   });
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -1,4 +1,13 @@
-import { mixed, boolean, string, number, object, ref, reach } from '../src';
+import {
+  mixed,
+  boolean,
+  string,
+  number,
+  object,
+  array,
+  ref,
+  reach,
+} from '../src';
 let noop = () => {};
 
 function ensureSync(fn) {
@@ -639,7 +648,7 @@ describe('Mixed Types ', () => {
   it('refs can access relative paths from inside an object', async function() {
     const prop = mixed().when('../relative', {
       is: true,
-      then: mixed().required('relative'),
+      then: mixed().required(),
     });
     const inst = object({
       relative: boolean(),
@@ -653,14 +662,45 @@ describe('Mixed Types ', () => {
         a: {},
       })
       .should.be.rejected();
-    // await inst
-    //   .validate({
-    //     relative:true,
-    //     // a:{
-    //     //   prop:1
-    //     // }
-    //   })
-    //   .should.be.fulfilled();
+    await inst
+      .validate({
+        relative: true,
+        a: {
+          prop: 1,
+        },
+      })
+      .should.be.fulfilled();
+  });
+
+  it('refs can access relative paths from inside an array', async function() {
+    const prop = mixed().when('../../relative', {
+      is: true,
+      then: mixed().required(),
+    });
+    const inst = object({
+      relative: boolean(),
+      a: array(
+        object({
+          prop: prop,
+        }),
+      ),
+    });
+    await inst
+      .validate({
+        relative: true,
+        a: [{}],
+      })
+      .should.be.rejected();
+    await inst
+      .validate({
+        relative: true,
+        a: [
+          {
+            prop: 1,
+          },
+        ],
+      })
+      .should.be.fulfilled();
   });
 
   it('should not use context refs in object calculations', function() {

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -1,4 +1,4 @@
-import { mixed, string, number, object, ref, reach } from '../src';
+import { mixed, boolean, string, number, object, ref, reach } from '../src';
 let noop = () => {};
 
 function ensureSync(fn) {
@@ -634,6 +634,33 @@ describe('Mixed Types ', () => {
       .validate('hello', { context: { prop: 1 } })
       .should.be.fulfilled();
     await inst.validate('hel', { context: { prop: 1 } }).should.be.rejected();
+  });
+
+  it('refs can access relative paths from inside an object', async function() {
+    const prop = mixed().when('../relative', {
+      is: true,
+      then: mixed().required('relative'),
+    });
+    const inst = object({
+      relative: boolean(),
+      a: object({
+        prop: prop,
+      }),
+    });
+    await inst
+      .validate({
+        relative: true,
+        a: {},
+      })
+      .should.be.rejected();
+    // await inst
+    //   .validate({
+    //     relative:true,
+    //     // a:{
+    //     //   prop:1
+    //     // }
+    //   })
+    //   .should.be.fulfilled();
   });
 
   it('should not use context refs in object calculations', function() {

--- a/test/util/makePath.js
+++ b/test/util/makePath.js
@@ -32,7 +32,7 @@ describe('makePath utils ', () => {
         key = '../key';
       expect(getRelativePath(path, key)).to.equal('a.key');
     });
-    it('should work for deep relative paths with an array', () => {
+    it('should generate a path relative to the current key', () => {
       const path = 'a.b[0].c',
         key = 'key';
       expect(getRelativePath(path, key)).to.equal('a.b[0].key');

--- a/test/util/makePath.js
+++ b/test/util/makePath.js
@@ -1,27 +1,41 @@
-import makePath from '../../src/util/makePath';
+import { default as makePath, getRelativePath } from '../../src/util/makePath';
 
-describe('makePath ', () => {
-  it('should be able to handle just a string', () => {
-    expect(makePath`path`).to.equal('path');
+describe('makePath utils ', () => {
+  describe('makePath', () => {
+    it('should be able to handle just a string', () => {
+      expect(makePath`path`).to.equal('path');
+    });
+    it('should be able to handle interpolating values into a template', () => {
+      const path = 'path',
+        key = 'key';
+      expect(makePath`${path}${key}`).to.equal('pathkey');
+    });
+    it('should be able to do complete string interpolation', () => {
+      const path = 'path',
+        key = 'key';
+      expect(makePath`${path}.${key}`).to.equal('path.key');
+    });
   });
-  it('should be able to handle interpolating values into a template', () => {
-    const path = 'path',
-      key = 'key';
-    expect(makePath`${path}${key}`).to.equal('pathkey');
-  });
-  it('should be able to do complete string interpolation', () => {
-    const path = 'path',
-      key = 'key';
-    expect(makePath`${path}.${key}`).to.equal('path.key');
-  });
-  it('should be able to handle relative paths', () => {
-    const path = 'a.b.c',
-      key = '../key';
-    expect(makePath`${path}.${key}`).to.equal('a.key');
-  });
-  it('should work for deep relative paths', () => {
-    const path = 'a.b.c',
-      key = '../../key';
-    expect(makePath`${path}.${key}`).to.equal('key');
+  describe('getRelativePath', () => {
+    it('should be able to handle relative paths', () => {
+      const path = 'a.b.c',
+        key = '../key';
+      expect(getRelativePath(path, key)).to.equal('a.key');
+    });
+    it('should work for deep relative paths', () => {
+      const path = 'a.b.c',
+        key = '../../key';
+      expect(getRelativePath(path, key)).to.equal('key');
+    });
+    it('should work for deep relative paths with an array', () => {
+      const path = 'a.b[0].c',
+        key = '../key';
+      expect(getRelativePath(path, key)).to.equal('a.key');
+    });
+    it('should work for deep relative paths with an array', () => {
+      const path = 'a.b[0].c',
+        key = 'key';
+      expect(getRelativePath(path, key)).to.equal('a.b[0].key');
+    });
   });
 });

--- a/test/util/makePath.js
+++ b/test/util/makePath.js
@@ -1,0 +1,27 @@
+import makePath from '../../src/util/makePath';
+
+describe('makePath ', () => {
+  it('should be able to handle just a string', () => {
+    expect(makePath`path`).to.equal('path');
+  });
+  it('should be able to handle interpolating values into a template', () => {
+    const path = 'path',
+      key = 'key';
+    expect(makePath`${path}${key}`).to.equal('pathkey');
+  });
+  it('should be able to do complete string interpolation', () => {
+    const path = 'path',
+      key = 'key';
+    expect(makePath`${path}.${key}`).to.equal('path.key');
+  });
+  it('should be able to handle relative paths', () => {
+    const path = 'a.b.c',
+      key = '../key';
+    expect(makePath`${path}.${key}`).to.equal('a.key');
+  });
+  it('should work for deep relative paths', () => {
+    const path = 'a.b.c',
+      key = '../../key';
+    expect(makePath`${path}.${key}`).to.equal('key');
+  });
+});


### PR DESCRIPTION
@jquense I am pretty sure this is going to be a contentious PR. The purpose of this PR is to allow refs to handle relative paths such as '.../key' so that they can find data relative to the field they are resolved in. Merging this would help for #165 , as well as for cases where you want to make a schema conditional on values in an array item when the field in question is nested. (reopening a new PR that does not have a mutilated git history... :( )