### PR TITLE
fix string.matches to throw error with correct message if second arg is omitted

### DIFF
--- a/src/string.js
+++ b/src/string.js
@@ -73,13 +73,15 @@ inherits(StringSchema, MixedSchema, {
     });
   },
 
-  matches(regex, options = {}) {
+  matches(regex, options) {
     let excludeEmptyString = false;
     let message;
 
-    if (options.message || options.hasOwnProperty('excludeEmptyString')) {
-      ({ excludeEmptyString, message } = options);
-    } else message = options;
+    if (options) {
+      if (options.message || options.hasOwnProperty('excludeEmptyString')) {
+        ({ excludeEmptyString, message } = options);
+      } else message = options;
+    }
 
     return this.test({
       message: message || locale.matches,


### PR DESCRIPTION
In code below, error messag to be a empty object `{}`.

```js
const schema = string().matches(/(hi|bye)/);

// default message is expected in message
schema
  .validate('nope')
  .catch(err => console.log(err));
```