### PR TITLE
Rename locale keys "less" and "more"

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -37,8 +37,8 @@ export let string = {
 export let number = {
   min: '${path} must be greater than or equal to ${min}',
   max: '${path} must be less than or equal to ${max}',
-  less: '${path} must be less than ${less}',
-  more: '${path} must be greater than ${more}',
+  lessThan: '${path} must be less than ${less}',
+  moreThan: '${path} must be greater than ${more}',
   notEqual: '${path} must be not equal to ${notEqual}',
   positive: '${path} must be a positive number',
   negative: '${path} must be a negative number',

--- a/src/number.js
+++ b/src/number.js
@@ -55,7 +55,7 @@ inherits(NumberSchema, MixedSchema, {
     });
   },
 
-  lessThan(less, message = locale.less) {
+  lessThan(less, message = locale.lessThan) {
     return this.test({
       message,
       name: 'max',
@@ -67,7 +67,7 @@ inherits(NumberSchema, MixedSchema, {
     });
   },
 
-  moreThan(more, message = locale.more) {
+  moreThan(more, message = locale.moreThan) {
     return this.test({
       message,
       name: 'min',

--- a/test/number.js
+++ b/test/number.js
@@ -160,14 +160,28 @@ describe('Number types', function() {
       valid: [4, -10, [null, schema.nullable()]],
       invalid: [5, 7, null, [14, schema.lessThan(10).lessThan(14)]],
     });
+
+    it('should return default message', () => {
+      return schema
+        .validate(6)
+        .should.be.rejected.and.eventually.have.property('errors')
+        .that.contain('this must be less than 5');
+    });
   });
 
-  describe('more', () => {
+  describe('moreThan', () => {
     var schema = number().moreThan(5);
 
     TestHelpers.validateAll(schema, {
       valid: [6, 56445435, [null, schema.nullable()]],
       invalid: [5, -10, null, [64, schema.moreThan(52).moreThan(74)]],
+    });
+
+    it('should return default message', () => {
+      return schema
+        .validate(4)
+        .should.be.rejected.and.eventually.have.property('errors')
+        .that.contain('this must be greater than 5');
     });
   });
 


### PR DESCRIPTION
Validations `lessThan` and `moreThan` use locale keys `less` and `more`. It seems these two are the only ones which use different naming for a method and locale key. It leads to an error with a `d.ts` file if you want to set up a custom locale. 

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/yup/index.d.ts#L253

I think it makes more sense to change the naming of locale keys rather than changing types definition.