### PR TITLE
Replace property-expr package to property-expr-csp

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@babel/runtime": "^7.0.0-beta.47",
     "fn-name": "~2.0.1",
     "lodash": "^4.17.10",
-    "property-expr": "^1.2.0",
+    "property-expr-csp": "^1.4.0",
     "synchronous-promise": "^1.0.18",
     "toposort": "^2.0.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,7 @@ const base = {
     'toposort',
     'fn-name',
     'synchronous-promise',
-    'property-expr',
+    'property-expr-csp',
   ],
 };
 

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -1,4 +1,4 @@
-import { getter } from 'property-expr';
+import { getter } from 'property-expr-csp';
 
 let validateName = d => {
   if (typeof d !== 'string')

--- a/src/object.js
+++ b/src/object.js
@@ -3,7 +3,7 @@ import snakeCase from 'lodash/snakeCase';
 import camelCase from 'lodash/camelCase';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
-import { getter } from 'property-expr';
+import { getter } from 'property-expr-csp';
 
 import MixedSchema from './mixed';
 import { object as locale } from './locale.js';

--- a/src/util/reach.js
+++ b/src/util/reach.js
@@ -1,4 +1,4 @@
-import { forEach } from 'property-expr';
+import { forEach } from 'property-expr-csp';
 import has from 'lodash/has';
 
 let trim = part => part.substr(0, part.length - 1).substr(1);

--- a/src/util/sortFields.js
+++ b/src/util/sortFields.js
@@ -1,6 +1,6 @@
 import has from 'lodash/has';
 import toposort from 'toposort';
-import { split } from 'property-expr';
+import { split } from 'property-expr-csp';
 
 import Ref from '../Reference';
 import isSchema from './isSchema';

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,11 +650,11 @@
     "@babel/plugin-transform-react-jsx-self" "7.0.0-beta.47"
     "@babel/plugin-transform-react-jsx-source" "7.0.0-beta.47"
 
-"@babel/runtime@7.0.0-beta.47":
-  version "7.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.47.tgz#273f5e71629e80f6cbcd7507503848615e59f7e0"
+"@babel/runtime@^7.0.0-beta.47":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.51.tgz#48b8ed18307034c6620f643514650ca2ccc0165a"
   dependencies:
-    core-js "^2.5.3"
+    core-js "^2.5.7"
     regenerator-runtime "^0.11.1"
 
 "@babel/template@7.0.0-beta.44":
@@ -1913,9 +1913,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^2.5.3:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -5095,9 +5095,9 @@ prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-property-expr@^1.2.0:
+property-expr-csp@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.4.0.tgz#e28cfe4e7a5a231fb14c8ad687a93a5342e05a8c"
+  resolved "https://registry.yarnpkg.com/property-expr-csp/-/property-expr-csp-1.4.0.tgz#92c0a5e88cbc2df6ad6e5c67670b65c7ff6c56c5"
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
To satisfy Content-Security-Policy requirements the package `property-expr-csp` was used instead `property-expr`. A new one has the same API, but doesn't cache getters and setters.