### PR TITLE
Use lodash/get in place of property-expr/getter due to strict CSP issues

### DIFF
--- a/src/Reference.js
+++ b/src/Reference.js
@@ -1,4 +1,4 @@
-import { getter } from 'property-expr';
+import get from 'lodash/get';
 
 let validateName = d => {
   if (typeof d !== 'string')
@@ -28,7 +28,7 @@ export default class Reference {
     this.isSelf = this.key === '.';
 
     this.path = this.isContext ? this.key.slice(this.prefix.length) : this.key;
-    this._get = getter(this.path, true);
+    this._get = obj => get(obj, this.path);
     this.map = mapFn || (value => value);
   }
   resolve() {

--- a/src/object.js
+++ b/src/object.js
@@ -3,7 +3,7 @@ import snakeCase from 'lodash/snakeCase';
 import camelCase from 'lodash/camelCase';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
-import { getter } from 'property-expr';
+import get from 'lodash/get';
 
 import MixedSchema from './mixed';
 import { object as locale } from './locale.js';
@@ -201,8 +201,6 @@ inherits(ObjectSchema, MixedSchema, {
   },
 
   from(from, to, alias) {
-    let fromGetter = getter(from, true);
-
     return this.transform(obj => {
       var newObj = obj;
 
@@ -212,7 +210,7 @@ inherits(ObjectSchema, MixedSchema, {
         newObj = { ...obj };
         if (!alias) delete obj[from];
 
-        newObj[to] = fromGetter(obj);
+        newObj[to] = get(obj, from);
       }
 
       return newObj;


### PR DESCRIPTION
See #135.

I understand that performance is a concern, but lodash's `get` util does do some caching under the hood. Hoping to get this merged as my current CSP is non-negotiable.