### PR TITLE
Update isSchema to always return a boolean

### DIFF
--- a/src/util/isSchema.js
+++ b/src/util/isSchema.js
@@ -1,1 +1,1 @@
-export default obj => obj && obj.__isYupSchema__;
+export default obj => !!(obj && obj.__isYupSchema__);

--- a/test/yup.js
+++ b/test/yup.js
@@ -2,7 +2,7 @@ import reach from '../src/util/reach';
 import merge from '../src/util/merge';
 import { settled } from '../src/util/runValidations';
 
-import { object, array, string, lazy, number } from '../src';
+import { object, array, string, lazy, number, isSchema } from '../src';
 
 describe('Yup', function() {
   it('cast should not assert on undefined', () => {
@@ -134,5 +134,13 @@ describe('Yup', function() {
       })
       .should.be.rejected();
     err.message.should.match(/must be a `number` type/);
+  });
+
+  it('should return boolean for isSchema', async () => {
+    isSchema(string()).should.equal(true);
+    isSchema({}).should.equal(false);
+    isSchema(undefined).should.equal(false);
+    isSchema(null).should.equal(false);
+    isSchema('').should.equal(false);
   });
 });


### PR DESCRIPTION
This is very minor, but given the naming of `isSchema`, I was surprised to find that it doesn't always return a boolean. This diff updates `isSchema` to always return a boolean.

I added a test, but I'm not sure if it's the best place to put it.

Please close if this change doesn't make sense :)