### PR TITLE
Pin beta packages to specific versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     ]
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.47",
-    "@babel/core": "^7.0.0-beta.47",
+    "@babel/cli": "7.0.0-beta.47",
+    "@babel/core": "7.0.0-beta.47",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.6",
     "babel-jest": "^22.4.3",
@@ -83,7 +83,7 @@
     "sinon-chai": "^3.2.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.47",
+    "@babel/runtime": "7.0.0-beta.47",
     "fn-name": "~2.0.1",
     "lodash": "^4.17.10",
     "property-expr": "^1.5.0",
@@ -91,7 +91,7 @@
     "toposort": "^2.0.2"
   },
   "resolutions": {
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.51"
+    "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.51"
   },
   "release-script": {
     "defaultDryRun": "false"


### PR DESCRIPTION
Yup pulls in the latest beta version of the Babel libraries, which sometimes break because they are in Beta. If beta libraries are required, they should be pinned to specific known-good versions. This PR does that.

Addresses the recurring issue here: https://github.com/jquense/yup/issues/216#issuecomment-411033919