### PR TITLE
chore: add runkit example

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.26.2",
   "description": "Dead simple Object schema validation",
   "main": "lib/index.js",
+  "runkitExampleFilename": "./runkit-example.js",
   "scripts": {
     "test": "npm run lint && npm run test-all -- --runInBand",
     "testonly": "jest",

--- a/runkit-example.js
+++ b/runkit-example.js
@@ -1,0 +1,22 @@
+const { object, string, number, date } = require('yup')
+
+const contactSchema = object({
+  name: string()
+    .required(),
+  age: number()
+    .required()
+    .positive()
+    .integer(),
+  email: string()
+    .email(),
+  website: string()
+    .url(),
+  createdOn: date()
+    .default(() => new Date())
+})
+
+contactSchema.cast({
+  name: 'jimmy',
+  age: '24',
+  createdOn: '2014-09-23T19:25:25Z'
+})


### PR DESCRIPTION
This PR makes it so that when people click the [test with runkit](https://npm.runkit.com/yup) link on npm the editor is pre-populated with a useful example instead of just a `require` statement.

![image](https://user-images.githubusercontent.com/174864/44066397-1d5a7e7e-9f3e-11e8-820a-5bee327909e1.png)
