### PR TITLE
Add function test names to email and url

### DIFF
--- a/src/string.js
+++ b/src/string.js
@@ -89,7 +89,7 @@ inherits(StringSchema, MixedSchema, {
     }
 
     return this.test({
-      name,
+      name: name || 'matches'
       message: message || locale.matches,
       params: { regex },
       test: value =>

--- a/src/string.js
+++ b/src/string.js
@@ -76,14 +76,20 @@ inherits(StringSchema, MixedSchema, {
   matches(regex, options) {
     let excludeEmptyString = false;
     let message;
+    let name;
 
     if (options) {
-      if (options.message || options.hasOwnProperty('excludeEmptyString')) {
-        ({ excludeEmptyString, message } = options);
+      if (
+        options.message ||
+        options.hasOwnProperty('excludeEmptyString') ||
+        options.name
+      ) {
+        ({ excludeEmptyString, message, name } = options);
       } else message = options;
     }
 
     return this.test({
+      name,
       message: message || locale.matches,
       params: { regex },
       test: value =>
@@ -95,6 +101,7 @@ inherits(StringSchema, MixedSchema, {
 
   email(message = locale.email) {
     return this.matches(rEmail, {
+      name: 'email',
       message,
       excludeEmptyString: true,
     });
@@ -102,6 +109,7 @@ inherits(StringSchema, MixedSchema, {
 
   url(message = locale.url) {
     return this.matches(rUrl, {
+      name: 'url',
       message,
       excludeEmptyString: true,
     });

--- a/src/string.js
+++ b/src/string.js
@@ -17,7 +17,7 @@ export default function StringSchema() {
   MixedSchema.call(this, { type: 'string' });
 
   this.withMutation(() => {
-    this.transform(function(value) {
+    this.transform(function (value) {
       if (this.isType(value)) return value;
       return value != null && value.toString ? value.toString() : value;
     });
@@ -89,7 +89,7 @@ inherits(StringSchema, MixedSchema, {
     }
 
     return this.test({
-      name: name || 'matches'
+      name: name || 'matches',
       message: message || locale.matches,
       params: { regex },
       test: value =>


### PR DESCRIPTION
I noticed that `string.email()` and `string.url()` don't have associated test function names and appear as `undefined` in the `tests` array of `SchemaDescription`. 

This just makes sure that a proper name is sent through the `matches` function.