### PR TITLE
Changes array.ensure to work on the original value

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,21 +609,20 @@ You can also specify more than one dependent key, in which case each value will 
 
 ```javascript
 var inst = yup.object({
-      isSpecial: yup.bool(),
-      isBig: yup.bool(),
-      count: yup.number()
-        .when(['isBig', 'isSpecial'], {
-          is: true,  // alternatively: (isBig, isSpecial) => isBig && isSpecial
-          then:      yup.number().min(5),
-          otherwise: yup.number().min(0)
-        })
-    })
+  isSpecial: yup.bool(),
+  isBig: yup.bool(),
+  count: yup.number().when(['isBig', 'isSpecial'], {
+    is: true, // alternatively: (isBig, isSpecial) => isBig && isSpecial
+    then: yup.number().min(5),
+    otherwise: yup.number().min(0),
+  }),
+});
 
 inst.validate({
   isBig: true,
   isSpecial: true,
-  count: 10
-})
+  count: 10,
+});
 ```
 
 Alternatively you can provide a function that returns a schema
@@ -984,6 +983,9 @@ array()
   .ensure()
   .cast([1]); // -> [1]
 ```
+
+Caveat: `ensure` casts the _original_ value to an array, and therefore ignores any
+transformations added before it.
 
 #### `array.compact(rejector: (value) => boolean): Schema`
 

--- a/src/array.js
+++ b/src/array.js
@@ -164,7 +164,10 @@ inherits(ArraySchema, MixedSchema, {
 
   ensure() {
     return this.default(() => []).transform(
-      val => (val === null ? [] : [].concat(val)),
+      // We transform the original value to allow a single element to
+      // get wrapped in an array. The transform added in the Array schema’s
+      // constructor turns non-array, non-JSON-string values into null.
+      (val, orig) => (orig === null ? [] : [].concat(orig)),
     );
   },
 

--- a/test/array.js
+++ b/test/array.js
@@ -173,5 +173,7 @@ describe('Array types', () => {
     inst.cast([1, 4]).should.eql([1, 4]);
 
     inst.cast(null).should.eql([]);
+
+    inst.cast(1).should.eql([1]);
   });
 });


### PR DESCRIPTION
This fixes to match the documentation, which says that a single element
should get cast to an array containing that element. Previously the
transform added in the constructor would convert non-arrays to null
before the ensure transform function would see them.

Fixes #343

WARNING: This is a breaking change. `ensure` now ignores any
transformations added before it, including the transform in the
constructor that parses JSON.