### PR TITLE
fix: cast() does not work well if scheme has stripped field.

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -104,7 +104,7 @@ inherits(ObjectSchema, MixedSchema, {
         field = field.resolve(innerOptions);
 
         if (field._strip === true) {
-          isChanged = true;
+          isChanged = isChanged || prop in value;
           return;
         }
 

--- a/test/object.js
+++ b/test/object.js
@@ -23,6 +23,7 @@ describe('Object types', () => {
         dte: date(),
         nested: object().shape({ str: string() }),
         arrNested: array().of(object().shape({ num: number() })),
+        stripped: string().strip(),
       });
     });
 


### PR DESCRIPTION
This is the small fix for #342: cast() returns new value even if nothing has changed, but scheme has a stripped field.