### PR TITLE
fix: validate() does not work with ref and abortEarly false. (#409)

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -163,6 +163,7 @@ inherits(ObjectSchema, MixedSchema, {
             innerOptions.strict = true;
 
             if (field.validate) return field.validate(value[key], innerOptions);
+            return Promise.resolve(true);
           }
 
           return true;

--- a/test/object.js
+++ b/test/object.js
@@ -382,6 +382,24 @@ describe('Object types', () => {
     });
   });
 
+  it('should allow refs with abortEarly false', async () => {
+    let schema = object().shape({
+      field: string(),
+      dupField: ref('field'),
+    });
+
+    let actual = await schema
+      .validate(
+        {
+          field: 'test',
+        },
+        { abortEarly: false },
+      )
+      .should.not.be.rejected();
+
+    actual.should.eql({ field: 'test', dupField: 'test' });
+  });
+
   describe('lazy evaluation', () => {
     let types = {
       string: string(),


### PR DESCRIPTION
Commented change on #409 to dont break Promise.all chain