### PR TITLE
replacing use of module.exports with ES export syntax to support SSR …

### DIFF
--- a/src/util/createValidation.js
+++ b/src/util/createValidation.js
@@ -27,7 +27,13 @@ function resolveParams(oldParams, newParams, resolve) {
   return mapValues({ ...oldParams, ...newParams }, resolve);
 }
 
-function createErrorFactory({ value, label, resolve, originalValue, ...opts }) {
+export function createErrorFactory({
+  value,
+  label,
+  resolve,
+  originalValue,
+  ...opts
+}) {
   return function createError({
     path = opts.path,
     message = opts.message,
@@ -98,5 +104,3 @@ export default function createValidation(options) {
 
   return validate;
 }
-
-module.exports.createErrorFactory = createErrorFactory;


### PR DESCRIPTION
Replacing use of `module.exports` with ES `export` syntax. This allowed me to use it in an SSR project with Next.js. I'm not sure that function needs exported at all (I didn't see any use within this package) but this should keep it exported just in case I'm missing something or external packages get at it.