### PR TITLE
Update README w/ proper default for nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ json separate from validating it, via the `cast` method.
     - [`mixed.withMutation(builder: (current: Schema) => void): void`](#mixedwithmutationbuilder-current-schema--void-void)
     - [`mixed.default(value: any): Schema`](#mixeddefaultvalue-any-schema)
     - [`mixed.default(): Any`](#mixeddefault-any)
-    - [`mixed.nullable(isNullable: boolean = false): Schema`](#mixednullableisnullable-boolean--false-schema)
+    - [`mixed.nullable(isNullable: boolean = true): Schema`](#mixednullableisnullable-boolean--true-schema)
     - [`mixed.required(message?: string | function): Schema`](#mixedrequiredmessage-string--function-schema)
     - [`mixed.notRequired(): Schema`](#mixednotrequired-schema)
     - [`mixed.typeError(message: string): Schema`](#mixedtypeerrormessage-string-schema)
@@ -540,7 +540,7 @@ yup.date.default(() => new Date()); //also helpful for defaults that change over
 
 Calling `default` with no arguments will return the current default value
 
-#### `mixed.nullable(isNullable: boolean = false): Schema`
+#### `mixed.nullable(isNullable: boolean = true): Schema`
 
 Indicates that `null` is a valid value for the schema. Without `nullable()`
 `null` is treated as a different type and will fail `isType()` checks.


### PR DESCRIPTION
The [documentation](https://github.com/jquense/yup#mixednullableisnullable-boolean--false-schema) for `mixed.nullable()` shows the typing as:

```
mixed.nullable(isNullable: boolean = false): Schema
```

This would imply that calling `yup.nullable()` sets the schema as **not** nullable. But in fact it does the opposite and sets the schema as nullable. Looking at [the implementation](https://github.com/jquense/yup/blob/master/src/mixed.js#L320), this is true:

```javascript
  nullable(value) {
    var next = this.clone();
    next._nullable = value === false ? false : true;
    return next;
  },
```

If the argument `value` is not provided, it will be `undefined`. That will not match `false`, so `next._nullable` will be set to `true`. So a more proper documented default value is `true`.