### PR TITLE
feat: support self references

### DIFF
--- a/src/Condition.js
+++ b/src/Condition.js
@@ -40,13 +40,9 @@ class Conditional {
     }
   }
 
-  getValue(value, parent, context) {
-    let values = this.refs.map(r => r.getValue(value, parent, context));
+  resolve(ctx, options) {
+    let values = this.refs.map(ref => ref.getValue(options));
 
-    return values;
-  }
-
-  resolve(ctx, values) {
     let schema = this.fn.apply(ctx, values.concat(ctx));
 
     if (schema !== undefined && !isSchema(schema))

--- a/src/Condition.js
+++ b/src/Condition.js
@@ -40,8 +40,8 @@ class Conditional {
     }
   }
 
-  getValue(parent, context) {
-    let values = this.refs.map(r => r.getValue(parent, context));
+  getValue(value, parent, context) {
+    let values = this.refs.map(r => r.getValue(value, parent, context));
 
     return values;
   }

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -380,6 +380,14 @@ const proto = (SchemaType.prototype = {
   },
 
   when(keys, options) {
+    if (arguments.length === 1) {
+      options = keys;
+      keys = '.';
+    } else if (isSchema(keys) || typeof keys === 'function') {
+      options = { ...options, is: keys };
+      keys = '.';
+    }
+
     var next = this.clone(),
       deps = [].concat(keys).map(key => new Ref(key));
 

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -134,11 +134,11 @@ const proto = (SchemaType.prototype = {
     return !this._typeCheck || this._typeCheck(v);
   },
 
-  resolve({ context, parent }) {
+  resolve({ value, parent, context }) {
     if (this._conditions.length) {
       return this._conditions.reduce(
         (schema, match) =>
-          match.resolve(schema, match.getValue(parent, context)),
+          match.resolve(schema, match.getValue(value, parent, context)),
         this,
       );
     }
@@ -147,7 +147,7 @@ const proto = (SchemaType.prototype = {
   },
 
   cast(value, options = {}) {
-    let resolvedSchema = this.resolve(options);
+    let resolvedSchema = this.resolve({ ...options, value });
     let result = resolvedSchema._cast(value, options);
 
     if (
@@ -240,12 +240,12 @@ const proto = (SchemaType.prototype = {
   },
 
   validate(value, options = {}) {
-    let schema = this.resolve(options);
+    let schema = this.resolve({ ...options, value });
     return schema._validate(value, options);
   },
 
   validateSync(value, options = {}) {
-    let schema = this.resolve(options);
+    let schema = this.resolve({ ...options, value });
     let result, err;
 
     schema
@@ -268,7 +268,7 @@ const proto = (SchemaType.prototype = {
 
   isValidSync(value, options) {
     try {
-      this.validateSync(value, { ...options });
+      this.validateSync(value, options);
       return true;
     } catch (err) {
       if (err.name === 'ValidationError') return false;
@@ -384,7 +384,7 @@ const proto = (SchemaType.prototype = {
       deps = [].concat(keys).map(key => new Ref(key));
 
     deps.forEach(dep => {
-      if (!dep.isContext) next._deps.push(dep.key);
+      if (dep.isSibling) next._deps.push(dep.key);
     });
 
     next._conditions.push(new Condition(deps, options));

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -134,11 +134,10 @@ const proto = (SchemaType.prototype = {
     return !this._typeCheck || this._typeCheck(v);
   },
 
-  resolve({ value, parent, context }) {
+  resolve(options) {
     if (this._conditions.length) {
       return this._conditions.reduce(
-        (schema, match) =>
-          match.resolve(schema, match.getValue(value, parent, context)),
+        (schema, condition) => condition.resolve(schema, options),
         this,
       );
     }
@@ -382,9 +381,6 @@ const proto = (SchemaType.prototype = {
   when(keys, options) {
     if (arguments.length === 1) {
       options = keys;
-      keys = '.';
-    } else if (isSchema(keys) || typeof keys === 'function') {
-      options = { ...options, is: keys };
       keys = '.';
     }
 

--- a/src/util/createValidation.js
+++ b/src/util/createValidation.js
@@ -68,8 +68,8 @@ export default function createValidation(options) {
     ...rest
   }) {
     let parent = options.parent;
-    let resolve = value =>
-      Ref.isRef(value) ? value.getValue(parent, options.context) : value;
+    let resolve = item =>
+      Ref.isRef(item) ? item.getValue(value, parent, options.context) : item;
 
     let createError = createErrorFactory({
       message,

--- a/src/util/createValidation.js
+++ b/src/util/createValidation.js
@@ -69,7 +69,9 @@ export default function createValidation(options) {
   }) {
     let parent = options.parent;
     let resolve = item =>
-      Ref.isRef(item) ? item.getValue(value, parent, options.context) : item;
+      Ref.isRef(item)
+        ? item.getValue({ value, parent, context: options.context })
+        : item;
 
     let createError = createErrorFactory({
       message,

--- a/src/util/sortFields.js
+++ b/src/util/sortFields.js
@@ -23,7 +23,7 @@ export default function sortFields(fields, excludes = []) {
 
       if (!~nodes.indexOf(key)) nodes.push(key);
 
-      if (Ref.isRef(value) && !value.isContext) addNode(value.path, key);
+      if (Ref.isRef(value) && value.isSibling) addNode(value.path, key);
       else if (isSchema(value) && value._deps)
         value._deps.forEach(path => addNode(path, key));
     }

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -735,6 +735,35 @@ describe('Mixed Types ', () => {
     await inst.validate(-1).should.be.fulfilled();
   });
 
+  it('should support conditional first argument as `is` shortcut', async function() {
+    let inst = number().when(value => value > 0, {
+      then: number().min(5),
+    });
+
+    await inst
+      .validate(4)
+      .should.be.rejectedWith(ValidationError, /must be greater/);
+
+    await inst.validate(5).should.be.fulfilled();
+
+    await inst.validate(-1).should.be.fulfilled();
+  });
+
+  it('should support conditional signle argument as options shortcut', async function() {
+    let inst = number().when({
+      is: value => value > 0,
+      then: number().min(5),
+    });
+
+    await inst
+      .validate(4)
+      .should.be.rejectedWith(ValidationError, /must be greater/);
+
+    await inst.validate(5).should.be.fulfilled();
+
+    await inst.validate(-1).should.be.fulfilled();
+  });
+
   it('should use label in error message', async function() {
     let label = 'Label';
     let inst = object({

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -720,6 +720,21 @@ describe('Mixed Types ', () => {
     inst.default().should.eql({ prop: undefined });
   });
 
+  it('should support self references in conditions', async function() {
+    let inst = number().when('.', {
+      is: value => value > 0,
+      then: number().min(5),
+    });
+
+    await inst
+      .validate(4)
+      .should.be.rejectedWith(ValidationError, /must be greater/);
+
+    await inst.validate(5).should.be.fulfilled();
+
+    await inst.validate(-1).should.be.fulfilled();
+  });
+
   it('should use label in error message', async function() {
     let label = 'Label';
     let inst = object({

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -656,7 +656,7 @@ describe('Mixed Types ', () => {
 
   it('should handle multiple conditionals', function() {
     let called = false;
-    let inst = mixed().when(['prop', 'other'], function(prop, other) {
+    let inst = mixed().when(['$prop', '$other'], function(prop, other) {
       other.should.equal(true);
       prop.should.equal(1);
       called = true;
@@ -665,7 +665,7 @@ describe('Mixed Types ', () => {
     inst.cast({}, { context: { prop: 1, other: true } });
     called.should.equal(true);
 
-    inst = mixed().when(['prop', 'other'], {
+    inst = mixed().when(['$prop', '$other'], {
       is: 5,
       then: mixed().required(),
     });
@@ -735,21 +735,7 @@ describe('Mixed Types ', () => {
     await inst.validate(-1).should.be.fulfilled();
   });
 
-  it('should support conditional first argument as `is` shortcut', async function() {
-    let inst = number().when(value => value > 0, {
-      then: number().min(5),
-    });
-
-    await inst
-      .validate(4)
-      .should.be.rejectedWith(ValidationError, /must be greater/);
-
-    await inst.validate(5).should.be.fulfilled();
-
-    await inst.validate(-1).should.be.fulfilled();
-  });
-
-  it('should support conditional signle argument as options shortcut', async function() {
+  it('should support conditional single argument as options shortcut', async function() {
     let inst = number().when({
       is: value => value > 0,
       then: number().min(5),


### PR DESCRIPTION
`key` cannot be a function since [`validateName`](https://github.com/jquense/yup/blob/d02ff5e59e004b4c5189d1b9fc0055cff45c61df/src/Reference.js#L3) ensures that it is a string.

`isSelf` is not used anywhere and `key="."` isn't supported by `property-expr` getter.

For working self references i opened [pull request](https://github.com/jquense/expr/pull/9) in `property-expr` to support empty string path. (currently `getter("")` works, but `getter("", true)` which is used in Reference.js throws)