### PR TITLE
feat: finalize resolve()

### DIFF
--- a/src/Condition.js
+++ b/src/Condition.js
@@ -1,52 +1,58 @@
 import has from 'lodash/has';
 import isSchema from './util/isSchema';
 
-function callOrConcat(schema) {
-  if (typeof schema === 'function') return schema;
-  if (!schema) return base => base;
-  return (base, options) => base.concat(schema.resolve(options));
+function wrapCusomFn(fn) {
+  return function(...args) {
+    args.pop();
+    return fn.apply(this, args);
+  };
 }
 
-class Conditional {
-  constructor(refs, options) {
-    let { is, then, otherwise } = options;
+function makeFn(options) {
+  if (typeof options === 'function') return wrapCusomFn(options);
 
-    this.refs = [].concat(refs);
+  if (!has(options, 'is'))
+    throw new TypeError('`is:` is required for `when()` conditions');
 
-    then = callOrConcat(then);
-    otherwise = callOrConcat(otherwise);
+  if (!options.then && !options.otherwise)
+    throw new TypeError(
+      'either `then:` or `otherwise:` is required for `when()` conditions',
+    );
 
-    if (typeof options === 'function') this.fn = options;
-    else {
-      if (!has(options, 'is'))
-        throw new TypeError('`is:` is required for `when()` conditions');
+  let { is, then, otherwise } = options;
 
-      if (!options.then && !options.otherwise)
-        throw new TypeError(
-          'either `then:` or `otherwise:` is required for `when()` conditions',
-        );
-
-      let isFn =
-        typeof is === 'function'
-          ? is
-          : (...values) => values.every(value => value === is);
-
-      this.fn = function(...values) {
-        let options = values.pop();
-        let schema = values.pop();
-        let option = isFn(...values) ? then : otherwise;
-
-        return option(schema, options);
-      };
-    }
+  let check;
+  if (typeof is === 'function') {
+    check = is;
+  } else {
+    check = (...values) => values.every(value => value === is);
   }
 
-  resolve(ctx, options) {
+  let fn = function(...args) {
+    let options = args.pop();
+    let schema = args.pop();
+    let branch = check(...args) ? then : otherwise;
+
+    if (!branch) return undefined;
+    if (typeof branch === 'function') return branch(schema);
+    return schema.concat(branch.resolve(options));
+  };
+
+  return fn;
+}
+
+class Condition {
+  constructor(refs, options) {
+    this.refs = refs;
+    this.fn = makeFn(options);
+  }
+
+  resolve(base, options) {
     let values = this.refs.map(ref => ref.getValue(options));
 
-    let schema = this.fn.apply(ctx, values.concat(ctx, options));
+    let schema = this.fn.apply(base, values.concat(base, options));
 
-    if (schema === undefined) return ctx;
+    if (schema === undefined || schema === base) return base;
 
     if (!isSchema(schema))
       throw new TypeError('conditions must return a schema object');
@@ -55,4 +61,4 @@ class Conditional {
   }
 }
 
-export default Conditional;
+export default Condition;

--- a/src/Lazy.js
+++ b/src/Lazy.js
@@ -2,16 +2,17 @@ import isSchema from './util/isSchema';
 
 class Lazy {
   constructor(mapFn) {
-    this._resolve = (...args) => {
-      let schema = mapFn(...args);
+    this._resolve = (value, options) => {
+      let schema = mapFn(value, options);
+
       if (!isSchema(schema))
         throw new TypeError('lazy() functions must return a valid schema');
 
-      return schema;
+      return schema.resolve(options);
     };
   }
-  resolve({ value, ...rest }) {
-    return this._resolve(value, rest);
+  resolve(options) {
+    return this._resolve(options.value, options);
   }
   cast(value, options) {
     return this._resolve(value, options).cast(value, options);

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -135,14 +135,22 @@ const proto = (SchemaType.prototype = {
   },
 
   resolve(options) {
-    if (this._conditions.length) {
-      return this._conditions.reduce(
+    let schema = this;
+
+    if (schema._conditions.length) {
+      let conditions = schema._conditions;
+
+      schema = schema.clone();
+      schema._conditions = [];
+      schema = conditions.reduce(
         (schema, condition) => condition.resolve(schema, options),
-        this,
+        schema,
       );
+
+      schema = schema.resolve(options);
     }
 
-    return this;
+    return schema;
   },
 
   cast(value, options = {}) {

--- a/src/util/reach.js
+++ b/src/util/reach.js
@@ -13,7 +13,7 @@ export function getIn(schema, path, value, context) {
     return {
       parent,
       parentPath: path,
-      schema: schema.resolve({ context, parent, value }),
+      schema,
     };
 
   forEach(path, (_part, isBracket, isArray) => {
@@ -54,10 +54,6 @@ export function getIn(schema, path, value, context) {
       lastPartDebug = isBracket ? '[' + _part + ']' : '.' + _part;
     }
   });
-
-  if (schema) {
-    schema = schema.resolve({ context, parent, value });
-  }
 
   return { schema, parent, parentPath: lastPart };
 }

--- a/test/object.js
+++ b/test/object.js
@@ -448,8 +448,12 @@ describe('Object types', () => {
         }),
       });
 
-      reach(inst, 'nested').should.equal(inst);
-      reach(inst, 'x.y').should.equal(inst);
+      reach(inst, 'nested')
+        .resolve({})
+        .should.equal(inst);
+      reach(inst, 'x.y')
+        .resolve({})
+        .should.equal(inst);
     });
 
     it('should be passed the value', done => {


### PR DESCRIPTION
This PR allows safely nest `lazy`s and `when`s in themselves and each other. (Asked in #335 for example)

Currently there is a difference between calling `resolve()` on `lazy` and on `mixed` with `when`s:

- `lazy.resolve()` will return a schema not connected to `lazy` instance. So calling `resolve()` on a returned schema does not call `lazy` body anymore.

- `mixed.resolve()` will return a schema resulted by `concat`ing base schema and conditional one, as nor `mixed.concat()` nor `mixed.resolve()` remove initial `when` conditions they are present in resulted schema and those conditions get called and merge their results on subsequent `resolve` calls of merged schema.

So, in a second case it is not a final resolve, but a partial one (resulted schema will contain conditions). For most cases it does not matter (though it cases unnecessary calls and may cause bugs for example with `reach`).

Here all `resolve`s are made equal and expect to return a non-lazy schema without any conditions remaining. So calling `resolve()` on a resulted schema will simply return it back. This also allows to make nested conditions and lazy to work without a problem.

It is a breaking change though, since before `reach()`ed schema's with `when`s where only partially resolved and expected to run those conditions again. This should be addressed. I think that there are three possible ways:

- Do not resolve `reach`ed schema. And if people need some methods which require resolved schema (like `meta()`) tell them about `resolve()`. So making `resolve()` part of public api.

- Keep `reach` behaviour the same, but add new function `getAt` (or something) which will return non resolved schema. And to tell people to use it now for most cases.

- Modify signature of `reach`, introduce flag for resolving or not. (Plus a `parent` option, since it may be used in top level `resolve` call.) So maybe reach will become `reach(schema, {path, value, parent, context, resolve})`.

(Personally i think first one is better, maybe third. Just suggestions.)

Half of proposal is to standardise `resolve()` behaviour and other half is to use created opportunity to nest things freely. 

(This also fixes #381 without #444, as now subsequent `resolve()` calls to do not cause repeats of `concat`s)

What do you think?