### PR TITLE
Update string().length() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ object()
 Sets a default value to use when the value is `undefined`.
 Defaults are created after transformations are executed, but before validations, to help ensure that safe
 defaults are specified. The default value will be cloned on each use, which can incur performance penalty
-for objects and arrays. To avoid this overhead you can also pass a function that returns an new default.
+for objects and arrays. To avoid this overhead you can also pass a function that returns a new default.
 Note that `null` is considered a separate non-empty value.
 
 ```js
@@ -784,11 +784,11 @@ Set a required length for the string value. The `${min}` interpolation can be us
 
 #### `string.min(limit: number | Ref, message?: string | function): Schema`
 
-Set an minimum length limit for the string value. The `${min}` interpolation can be used in the `message` argument
+Set a minimum length limit for the string value. The `${min}` interpolation can be used in the `message` argument
 
 #### `string.max(limit: number | Ref, message?: string | function): Schema`
 
-Set an maximum length limit for the string value. The `${max}` interpolation can be used in the `message` argument
+Set a maximum length limit for the string value. The `${max}` interpolation can be used in the `message` argument
 
 #### `string.matches(regex: Regex, message?: string | function): Schema`
 
@@ -970,11 +970,11 @@ The same as the `mixed()` schema required, except that empty arrays are also con
 
 #### `array.min(limit: number | Ref, message?: string | function): Schema`
 
-Set an minimum length limit for the array. The `${min}` interpolation can be used in the `message` argument.
+Set a minimum length limit for the array. The `${min}` interpolation can be used in the `message` argument.
 
 #### `array.max(limit: number | Ref, message?: string | function): Schema`
 
-Set an maximum length limit for the array. The `${max}` interpolation can be used in the `message` argument.
+Set a maximum length limit for the array. The `${max}` interpolation can be used in the `message` argument.
 
 #### `array.ensure(): Schema`
 

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ The same as the `mixed()` schema required, except that empty strings are also co
 
 #### `string.length(limit: number | Ref, message?: string | function): Schema`
 
-Set a required length for the string value. The `${min}` interpolation can be used in the `message` argument
+Set a required length for the string value. The `${length}` interpolation can be used in the `message` argument
 
 #### `string.min(limit: number | Ref, message?: string | function): Schema`
 

--- a/README.md
+++ b/README.md
@@ -778,6 +778,10 @@ Failed casts return the input value.
 
 The same as the `mixed()` schema required, except that empty strings are also considered 'missing' values.
 
+#### `string.length(limit: number | Ref, message?: string | function): Schema`
+
+Set a required length for the string value. The `${min}` interpolation can be used in the `message` argument
+
 #### `string.min(limit: number | Ref, message?: string | function): Schema`
 
 Set an minimum length limit for the string value. The `${min}` interpolation can be used in the `message` argument

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ json separate from validating it, via the `cast` method.
     - [`mixed.transform((currentValue: any, originalValue: any) => any): Schema`](#mixedtransformcurrentvalue-any-originalvalue-any--any-schema)
   - [string](#string)
     - [`string.required(message?: string | function): Schema`](#stringrequiredmessage-string--function-schema)
+    - [`string.length(limit: number | Ref, message?: string | function): Schema`](#stringlengthlimit-number--ref-message-string--function-schema)
     - [`string.min(limit: number | Ref, message?: string | function): Schema`](#stringminlimit-number--ref-message-string--function-schema)
     - [`string.max(limit: number | Ref, message?: string | function): Schema`](#stringmaxlimit-number--ref-message-string--function-schema)
     - [`string.matches(regex: Regex, message?: string | function): Schema`](#stringmatchesregex-regex-message-string--function-schema)


### PR DESCRIPTION
Related to [Issue #418](https://github.com/jquense/yup/issues/418). You have already merged a PR that adds the documentation for the method. I then realized that I had not added the link that the top of the README to scroll the user down to the documentation. Sorry about that! 