### PR TITLE
fix: noUnknown() overriding

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -240,7 +240,7 @@ inherits(ObjectSchema, MixedSchema, {
       },
     });
 
-    if (noAllow) next._options.stripUnknown = true;
+    next._options.stripUnknown = noAllow;
 
     return next;
   },

--- a/test/object.js
+++ b/test/object.js
@@ -329,6 +329,17 @@ describe('Object types', () => {
     ]);
   });
 
+  it('should work with noUnknown override', async () => {
+    let inst = object()
+      .shape({
+        prop: mixed(),
+      })
+      .noUnknown()
+      .noUnknown(false);
+
+    await inst.validate({ extra: 'field' }).should.become({ extra: 'field' });
+  });
+
   it('should strip specific fields', () => {
     let inst = object().shape({
       prop: mixed().strip(false),


### PR DESCRIPTION
Right now `noUnknown()` changes `_options.stripUnknown` only when `noAllow` is true. So when `noAllow` is `false` in override the option still remains `true`.