### PR TITLE
fix: default message for test with object

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -338,15 +338,21 @@ const proto = (SchemaType.prototype = {
    * the previous tests are removed and further tests of the same name will replace each other.
    */
   test(...args) {
-    let opts = args[0];
-    if (args.length > 1) {
-      let [name, message, test] = args;
-      if (test == null) {
-        test = message;
-        message = locale.default;
+    let opts;
+
+    if (args.length === 1) {
+      if (typeof args[0] === 'function') {
+        opts = { test: args[0] };
+      } else {
+        opts = args[0];
       }
-      opts = { name, test, message, exclusive: false };
+    } else if (args.length === 2) {
+      opts = { name: args[0], test: args[1] };
+    } else {
+      opts = { name: args[0], message: args[1], test: args[2] };
     }
+
+    if (opts.message === undefined) opts.message = locale.default;
 
     if (typeof opts.test !== 'function')
       throw new TypeError('`test` is a required parameters');

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -349,6 +349,14 @@ describe('Mixed Types ', () => {
     inst.tests[0].OPTIONS.message.should.equal('${path} is invalid');
   });
 
+  it('should fallback to default message', async () => {
+    let inst = mixed().test(() => false);
+
+    await inst
+      .validate('foo')
+      .should.be.rejectedWith(ValidationError, 'this is invalid');
+  });
+
   it('should allow non string messages', async () => {
     let message = { key: 'foo' };
     let inst = mixed().test('test', message, () => false);


### PR DESCRIPTION
Two things:

1) Fix. If you use `test()` with multiply arguments like `test('name', func)` then you will be provided with default message (`locale.default`). But not if you use it with `opts` object without message `test(opts)` or with second argument as `undefined` `test('name', undefined, func)` (it is assumed right now that since there are 3 arguments then message is present). Now all variants treated equally and if message is `undefined` then it will be set to `locale.default`.

2) Small feature. Now it is possible to write `test(func)`. Since `name` is needed only for exclusive tests it can be omitted (like it is possible to omit it in `opts` form).