### PR TITLE
feat: various improvements and fixes

### DIFF
--- a/src/boolean.js
+++ b/src/boolean.js
@@ -1,9 +1,7 @@
 import inherits from './util/inherits';
 import MixedSchema from './mixed';
 
-export default BooleanSchema;
-
-function BooleanSchema() {
+export default function BooleanSchema() {
   if (!(this instanceof BooleanSchema)) return new BooleanSchema();
 
   MixedSchema.call(this, { type: 'boolean' });

--- a/src/date.js
+++ b/src/date.js
@@ -2,16 +2,13 @@ import MixedSchema from './mixed';
 import inherits from './util/inherits';
 import isoParse from './util/isodate';
 import { date as locale } from './locale';
-import isAbsent from './util/isAbsent';
 import Ref from './Reference';
 
 let invalidDate = new Date('');
 
 let isDate = obj => Object.prototype.toString.call(obj) === '[object Date]';
 
-export default DateSchema;
-
-function DateSchema() {
+export default function DateSchema() {
   if (!(this instanceof DateSchema)) return new DateSchema();
 
   MixedSchema.call(this, { type: 'date' });
@@ -47,8 +44,9 @@ inherits(DateSchema, MixedSchema, {
       name: 'min',
       exclusive: true,
       params: { min },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value >= this.resolve(limit);
+        return value >= this.resolve(limit);
       },
     });
   },
@@ -69,8 +67,9 @@ inherits(DateSchema, MixedSchema, {
       name: 'max',
       exclusive: true,
       params: { max },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value <= this.resolve(limit);
+        return value <= this.resolve(limit);
       },
     });
   },

--- a/src/number.js
+++ b/src/number.js
@@ -5,8 +5,6 @@ import isAbsent from './util/isAbsent';
 
 let isNaN = value => value != +value;
 
-let isInteger = val => isAbsent(val) || val === (val | 0);
-
 export default function NumberSchema() {
   if (!(this instanceof NumberSchema)) return new NumberSchema();
 
@@ -14,8 +12,8 @@ export default function NumberSchema() {
 
   this.withMutation(() => {
     this.transform(function(value) {
-      let parsed = value
-      
+      let parsed = value;
+
       if (typeof parsed === 'string') {
         parsed = parsed.replace(/\s/g, '');
         if (parsed === '') return NaN;
@@ -43,8 +41,9 @@ inherits(NumberSchema, MixedSchema, {
       name: 'min',
       exclusive: true,
       params: { min },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value >= this.resolve(min);
+        return value >= this.resolve(min);
       },
     });
   },
@@ -55,8 +54,9 @@ inherits(NumberSchema, MixedSchema, {
       name: 'max',
       exclusive: true,
       params: { max },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value <= this.resolve(max);
+        return value <= this.resolve(max);
       },
     });
   },
@@ -67,8 +67,9 @@ inherits(NumberSchema, MixedSchema, {
       name: 'max',
       exclusive: true,
       params: { less },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value < this.resolve(less);
+        return value < this.resolve(less);
       },
     });
   },
@@ -79,8 +80,9 @@ inherits(NumberSchema, MixedSchema, {
       name: 'min',
       exclusive: true,
       params: { more },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value > this.resolve(more);
+        return value > this.resolve(more);
       },
     });
   },
@@ -94,7 +96,13 @@ inherits(NumberSchema, MixedSchema, {
   },
 
   integer(message = locale.integer) {
-    return this.test({ name: 'integer', message, test: isInteger });
+    return this.test({
+      message,
+      name: 'integer',
+      exclusive: true,
+      skipAbsent: true,
+      test: value => value === (value | 0),
+    });
   },
 
   truncate() {

--- a/src/string.js
+++ b/src/string.js
@@ -1,15 +1,11 @@
 import inherits from './util/inherits';
 import MixedSchema from './mixed';
-import { mixed, string as locale } from './locale';
-import isAbsent from './util/isAbsent';
+import { string as locale } from './locale';
 
 // eslint-disable-next-line
 let rEmail = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
 // eslint-disable-next-line
 let rUrl = /^((https?|ftp):)?\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
-
-let hasLength = value => isAbsent(value) || value.length > 0;
-let isTrimmed = value => isAbsent(value) || value === value.trim();
 
 export default function StringSchema() {
   if (!(this instanceof StringSchema)) return new StringSchema();
@@ -31,10 +27,8 @@ inherits(StringSchema, MixedSchema, {
     return typeof value === 'string';
   },
 
-  required(message = mixed.required) {
-    var next = MixedSchema.prototype.required.call(this, message);
-
-    return next.test({ message, name: 'required', test: hasLength });
+  _isFilled(value) {
+    return value.length > 0;
   },
 
   length(length, message = locale.length) {
@@ -43,8 +37,9 @@ inherits(StringSchema, MixedSchema, {
       name: 'length',
       exclusive: true,
       params: { length },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value.length === this.resolve(length);
+        return value.length === this.resolve(length);
       },
     });
   },
@@ -55,47 +50,53 @@ inherits(StringSchema, MixedSchema, {
       name: 'min',
       exclusive: true,
       params: { min },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value.length >= this.resolve(min);
+        return value.length >= this.resolve(min);
       },
     });
   },
 
   max(max, message = locale.max) {
     return this.test({
+      message,
       name: 'max',
       exclusive: true,
-      message,
       params: { max },
+      skipAbsent: true,
       test(value) {
-        return isAbsent(value) || value.length <= this.resolve(max);
+        return value.length <= this.resolve(max);
       },
     });
   },
 
-  matches(regex, options) {
-    let excludeEmptyString = false;
-    let message;
-
-    if (options) {
-      if (options.message || options.hasOwnProperty('excludeEmptyString')) {
-        ({ excludeEmptyString, message } = options);
-      } else message = options;
+  matches(regex, options = {}) {
+    if (typeof options === 'string' || typeof options === 'function') {
+      options = { message: options };
     }
 
+    let {
+      message = locale.matches,
+      name = 'matches',
+      exclusive = false,
+      excludeEmptyString = false,
+    } = options;
+
     return this.test({
-      message: message || locale.matches,
+      message,
+      name,
+      exclusive,
       params: { regex },
-      test: value =>
-        isAbsent(value) ||
-        (value === '' && excludeEmptyString) ||
-        regex.test(value),
+      skipAbsent: true,
+      test: value => (value === '' && excludeEmptyString) || regex.test(value),
     });
   },
 
   email(message = locale.email) {
     return this.matches(rEmail, {
       message,
+      name: 'email',
+      exclusive: true,
       excludeEmptyString: true,
     });
   },
@@ -103,42 +104,52 @@ inherits(StringSchema, MixedSchema, {
   url(message = locale.url) {
     return this.matches(rUrl, {
       message,
+      name: 'url',
+      exclusive: true,
       excludeEmptyString: true,
     });
   },
 
   //-- transforms --
   ensure() {
-    return this.default('').transform(val => (val === null ? '' : val));
+    return this.clone(next => {
+      next.default('');
+      next.transform(value => (value === null ? '' : value));
+    });
   },
 
   trim(message = locale.trim) {
-    return this.transform(val => (val != null ? val.trim() : val)).test({
-      message,
-      name: 'trim',
-      test: isTrimmed,
+    return this.clone(next => {
+      next.transform(value => value && value.trim());
+      next.test({
+        message,
+        name: 'trim',
+        exclusive: true,
+        skipAbsent: true,
+        test: value => value === value.trim(),
+      });
+    });
+  },
+
+  _case(name, transform, message) {
+    return this.clone(next => {
+      next.transform(value => value && transform(value));
+      next.test({
+        message,
+        name: 'case',
+        exclusive: true,
+        params: { name },
+        skipAbsent: true,
+        test: value => value === transform(value),
+      });
     });
   },
 
   lowercase(message = locale.lowercase) {
-    return this.transform(
-      value => (!isAbsent(value) ? value.toLowerCase() : value),
-    ).test({
-      message,
-      name: 'string_case',
-      exclusive: true,
-      test: value => isAbsent(value) || value === value.toLowerCase(),
-    });
+    return this._case('lowercase', value => value.toLowerCase(), message);
   },
 
   uppercase(message = locale.uppercase) {
-    return this.transform(
-      value => (!isAbsent(value) ? value.toUpperCase() : value),
-    ).test({
-      message,
-      name: 'string_case',
-      exclusive: true,
-      test: value => isAbsent(value) || value === value.toUpperCase(),
-    });
+    return this._case('uppercase', value => value.toUpperCase(), message);
   },
 });

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -545,7 +545,7 @@ describe('Mixed Types ', () => {
     });
 
     it('should have the correct number of tests', () => {
-      reach(next, 'str').tests.length.should.equal(3); // presence, alt presence, and trim
+      reach(next, 'str').tests.length.should.equal(2);
     });
 
     it('should have the tests in the correct order', () => {


### PR DESCRIPTION
### Fixes

1) **Fixes** `array.notRequired()`/`string.notRequired()`. Currently they have overridden  `required()`, but not `notRequired()`.

```js
array().required().notRequired().isValidSync([]) // now true, not false
```

2) **Fixes** `cast()` for `object()` and value with a key which is present in `Object.prototype`.

```js
object().required().cast({toString: 5}); // now does not throw
```

3) **Fixes** `withMutation()` and nested invocation.

```js
mixed().withMutation(schema => {
  schema.withMutation(changeA);
  changeB(schema);
}); // now changeB gets mutable instance
```

4) **Fixes** `describe()` which currently ignores tests with same name but different params, showing only first one of them. 

```js
string().matches(/a/).matches(/b/).describe() // now have two tests, not one
```

### Additions

5) **Adds** `skipAbsent` option to tests. Currently most tests in codebase have `isAbsent(value)` check in their functions. To skip those tests from the start and make functions cleaner, the option was added.

```js
this.test({
  skipAbsent: true,
  ...
}); // this test will be skipped if a value is null or undefined
```

6) **Adds** boolean argument to `strict()` and `nullable()` in case when one wants to revert effect. (`strict()` has such argument mentioned in readme, but currently it is not present)

```js
mixed().nullable().nullable(false); // not nullable anymore
```

7) **Adds** a function argument to `clone()`, if present is passed to `withMutation()` of a clone. Uses this to reduce cloning in some method.

```js
this.clone(next => {
  next.transform(...);
  next.test(...);
}); // instead of this.transform().test() which does cloning twice
```

8) **Adds** `optional()` alias for `notRequired()` and `unknown()` as opposite to `noUnknown()`.

```is
number().optional(); // reads better and present in joi, same with unknown().
```

### Changes

9) **Changes (fixes)** behaviour of `notRequired()` not concating and `noUnknown` still being present in `describe()` output even if `noAllow` is `false`. Both problems connected with way to remove a test. `notRequired()` simply removes test by name, but this leaves no trace of user's action or intent, so it is lost for `concat()`. `noUnknown()` uses `exclusive` option to replace test with new one, but it needlessly runs and gets present in `describe`. Solution is to add new test option `skip`. Tests with `skip` as `true` do not run and do not get `describe`d. Useful with `exclusive` option. Plus added `mixed.skip(name)` method, which adds a test with provided `name` and `exclusive`/`skip` as `true`.

```js
object().noUnknown().concat(object.noUnknown(false)).validateSync({ foo: 'bar' });
// => true, as before

mixed().required().concat(mixed()).validateSync(undefined);
// => false, as before

mixed().required().concat(mixed().notRequired()).validateSync(undefined);
// => true, not false as before
```

Will split into multiple PR later. Opened to get feedback. I assume there will be no problems with first seven ones. 

- Do you have any problems with adding aliases in number 8?
- Should last example in number 9 return `true` or `false`? If `false`, why?