### PR TITLE
fix: object and prototype keys

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -38,7 +38,7 @@ export default function ObjectSchema(spec) {
     },
   });
 
-  this.fields = Object.create(null);
+  this.fields = {};
   this._nodes = [];
   this._excludedEdges = [];
 
@@ -93,7 +93,7 @@ inherits(ObjectSchema, MixedSchema, {
       let field = fields[prop];
       let exists = has(value, prop);
 
-      if (field) {
+      if (field && field.resolve) {
         let fieldValue;
         let strict = field._options && field._options.strict;
 


### PR DESCRIPTION
Number 2 from #454

`fields = Object.create(null)` does not work as a way to ignore prototype properties since after first `clone()` it will be a usual object.

```js
object().required().validateSync({toString: 5}); // now does not throw
```