### PR TITLE
fix: concat of required() for array/string

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -4,10 +4,8 @@ import isSchema from './util/isSchema';
 import makePath from './util/makePath';
 import printValue from './util/printValue';
 import MixedSchema from './mixed';
-import { mixed, array as locale } from './locale';
+import { array as locale } from './locale';
 import runValidations, { propagateErrors } from './util/runValidations';
-
-let hasLength = value => !isAbsent(value) && value.length > 0;
 
 export default ArraySchema;
 
@@ -110,6 +108,10 @@ inherits(ArraySchema, MixedSchema, {
       });
   },
 
+  _isFilled(value) {
+    return value.length > 0;
+  },
+
   of(schema) {
     var next = this.clone();
 
@@ -123,16 +125,6 @@ inherits(ArraySchema, MixedSchema, {
     next._subType = schema;
 
     return next;
-  },
-
-  required(message = mixed.required) {
-    var next = MixedSchema.prototype.required.call(this, message);
-
-    return next.test({
-      message,
-      name: 'required',
-      test: hasLength,
-    });
   },
 
   min(min, message) {

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -13,8 +13,6 @@ import printValue from './util/printValue';
 import Ref from './Reference';
 import { getIn } from './util/reach';
 
-let notEmpty = value => !isAbsent(value);
-
 class RefSet {
   constructor() {
     this.list = new Set();
@@ -302,8 +300,19 @@ const proto = (SchemaType.prototype = {
     return next;
   },
 
+  _isFilled(_) {
+    return true;
+  },
+
   required(message = locale.required) {
-    return this.test({ message, name: 'required', test: notEmpty });
+    return this.test({
+      message,
+      name: 'required',
+      exclusive: true,
+      test(value) {
+        return !isAbsent(value) && this.schema._isFilled(value);
+      },
+    });
   },
 
   notRequired() {

--- a/src/string.js
+++ b/src/string.js
@@ -1,6 +1,6 @@
 import inherits from './util/inherits';
 import MixedSchema from './mixed';
-import { mixed, string as locale } from './locale';
+import { string as locale } from './locale';
 import isAbsent from './util/isAbsent';
 
 // eslint-disable-next-line
@@ -8,7 +8,6 @@ let rEmail = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\u
 // eslint-disable-next-line
 let rUrl = /^((https?|ftp):)?\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
 
-let hasLength = value => isAbsent(value) || value.length > 0;
 let isTrimmed = value => isAbsent(value) || value === value.trim();
 
 export default function StringSchema() {
@@ -31,10 +30,8 @@ inherits(StringSchema, MixedSchema, {
     return typeof value === 'string';
   },
 
-  required(message = mixed.required) {
-    var next = MixedSchema.prototype.required.call(this, message);
-
-    return next.test({ message, name: 'required', test: hasLength });
+  _isFilled(value) {
+    return value.length > 0;
   },
 
   length(length, message = locale.length) {

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -545,7 +545,7 @@ describe('Mixed Types ', () => {
     });
 
     it('should have the correct number of tests', () => {
-      reach(next, 'str').tests.length.should.equal(3); // presence, alt presence, and trim
+      reach(next, 'str').tests.length.should.equal(2);
     });
 
     it('should have the tests in the correct order', () => {


### PR DESCRIPTION
Number 1 from #454

Removed redefinition of `required()` from `array` and `string`, instead added `_isFilled(value)` method for subtypes to override. Redefinition of `required()` causes problems with `concat`:

```js
mixed().required().concat(array()).isValidSync([]); // now false, not true
```