### PR TITLE
feat: aliases `optional()` and `unknown()`

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -512,3 +512,4 @@ for (const method of ['validate', 'validateSync'])
 
 for (const alias of ['equals', 'is']) proto[alias] = proto.oneOf;
 for (const alias of ['not', 'nope']) proto[alias] = proto.notOneOf;
+proto.optional = proto.notRequired;

--- a/src/object.js
+++ b/src/object.js
@@ -245,6 +245,10 @@ inherits(ObjectSchema, MixedSchema, {
     return next;
   },
 
+  unknown(allow = true, message = locale.noUnknown) {
+    return this.noUnknown(!allow, message);
+  },
+
   transformKeys(fn) {
     return this.transform(obj => obj && mapKeys(obj, (_, key) => fn(key)));
   },


### PR DESCRIPTION
Number 8 from #454 

```js
number().optional(); // reads better and present in joi, same with unknown().
```