### PR TITLE
fix: remove unneeded clone() in describe()

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -480,13 +480,11 @@ const proto = (SchemaType.prototype = {
   },
 
   describe() {
-    const next = this.clone();
-
     return {
-      type: next._type,
-      meta: next._meta,
-      label: next._label,
-      tests: next.tests
+      type: this._type,
+      meta: this._meta,
+      label: this._label,
+      tests: this.tests
         .map(fn => ({ name: fn.OPTIONS.name, params: fn.OPTIONS.params }))
         .filter(
           (n, idx, list) => list.findIndex(c => c.name === n.name) === idx,


### PR DESCRIPTION
What's the purpose of clone here?

If you still want to make clone (to prevent modification for `_meta` and `OPTIONS.params`), we can simply wrap the result in `cloneDeepWith()`.