### PR TITLE
Added precision method on number

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -43,6 +43,7 @@ export let number = {
   positive: '${path} must be a positive number',
   negative: '${path} must be a negative number',
   integer: '${path} must be an integer',
+  precision: '${path} must have no more than ${decimalPlaces} decimal places',
 };
 
 export let date = {

--- a/src/number.js
+++ b/src/number.js
@@ -14,8 +14,8 @@ export default function NumberSchema() {
 
   this.withMutation(() => {
     this.transform(function(value) {
-      let parsed = value
-      
+      let parsed = value;
+
       if (typeof parsed === 'string') {
         parsed = parsed.replace(/\s/g, '');
         if (parsed === '') return NaN;
@@ -113,8 +113,29 @@ inherits(NumberSchema, MixedSchema, {
         'Only valid options for round() are: ' + avail.join(', '),
       );
 
-    return this.transform(
-      value => (!isAbsent(value) ? Math[method](value) : value),
+    return this.transform(value =>
+      !isAbsent(value) ? Math[method](value) : value,
     );
+  },
+
+  precision(decimalPlaces, decimalSeparator = '.', message = locale.precision) {
+    return this.test({
+      message,
+      name: 'precision',
+      params: { decimalPlaces },
+      test(value) {
+        value = value.toString();
+        const decimalIndex = value.indexOf(decimalSeparator);
+        const decimalValue =
+          decimalIndex > -1
+            ? value.substring(decimalIndex + 1, value.length)
+            : '';
+
+        return (
+          decimalPlaces >= 0 &&
+          decimalValue.length <= this.resolve(decimalPlaces)
+        );
+      },
+    });
   },
 });

--- a/test/number.js
+++ b/test/number.js
@@ -215,6 +215,29 @@ describe('Number types', function() {
     });
   });
 
+  describe('precision', () => {
+    let schema = number().precision(0);
+
+    TestHelpers.validateAll(schema, {
+      valid: [6, 7],
+      invalid: [6.222, 7.499, 6.1, 6.22],
+    });
+
+    schema = number().precision(2);
+
+    TestHelpers.validateAll(schema, {
+      valid: [6, 6.1, 6.22, 7.42],
+      invalid: [6.222, 7.599],
+    });
+
+    it('should return default message', () => {
+      return schema
+        .validate(6.222)
+        .should.be.rejected.and.eventually.have.property('errors')
+        .that.contain('this must have no more than 2 decimal places');
+    });
+  });
+
   it('should check POSITIVE correctly', function() {
     var v = number().positive();
 


### PR DESCRIPTION
Perhaps `decimalSeparator` shouldn't be a parameter on the `precision` method but should instead be part of a locale configuration?