### PR TITLE
Allow access to parent schema (and unlimited ancestors!) in test context

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -89,6 +89,7 @@ inherits(ArraySchema, MixedSchema, {
             path,
             strict: true,
             parent: value,
+            index: idx,
             originalValue: originalValue[idx],
           };
 

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -269,9 +269,7 @@ const proto = (SchemaType.prototype = {
         sync,
         value,
         endEarly,
-        validations: this.tests.map(fn => {
-          return fn(validationParams);
-        }),
+        validations: this.tests.map(fn => fn(validationParams)),
       }),
     );
   },

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -243,8 +243,8 @@ const proto = (SchemaType.prototype = {
       sync,
     };
 
-    if (options.parentSchema) {
-      validationParams.parentSchema = options.parentSchema;
+    if (options.from) {
+      validationParams.from = options.from;
     }
 
     let initialTests = [];

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -242,6 +242,11 @@ const proto = (SchemaType.prototype = {
       originalValue,
       sync,
     };
+
+    if (options.parentSchema) {
+      validationParams.parentSchema = options.parentSchema;
+    }
+
     let initialTests = [];
 
     if (this._typeError) initialTests.push(this._typeError(validationParams));
@@ -264,7 +269,9 @@ const proto = (SchemaType.prototype = {
         sync,
         value,
         endEarly,
-        validations: this.tests.map(fn => fn(validationParams)),
+        validations: this.tests.map(fn => {
+          return fn(validationParams);
+        }),
       }),
     );
   },
@@ -550,7 +557,6 @@ for (const method of ['validate', 'validateSync'])
       value,
       options.context,
     );
-
     return schema[method](parent && parent[parentPath], {
       ...options,
       parent,

--- a/src/object.js
+++ b/src/object.js
@@ -131,7 +131,7 @@ inherits(ObjectSchema, MixedSchema, {
     endEarly = this._option('abortEarly', opts);
     recursive = this._option('recursive', opts);
 
-    opts = { ...opts, __validating: true, originalValue };
+    opts = { ...opts, __validating: true, originalValue, parentSchema: this };
 
     return MixedSchema.prototype._validate
       .call(this, _value, opts)
@@ -156,6 +156,7 @@ inherits(ObjectSchema, MixedSchema, {
             ...opts,
             path,
             parent: value,
+            parentSchema: this,
             originalValue: originalValue[key],
           };
 

--- a/src/object.js
+++ b/src/object.js
@@ -128,11 +128,7 @@ inherits(ObjectSchema, MixedSchema, {
     let originalValue =
       opts.originalValue != null ? opts.originalValue : _value;
 
-    let fromClosure = (scope, from) => () => {
-      return { value: originalValue, schema: scope, from };
-    };
-
-    let from = fromClosure(this, opts.from);
+    let from = [{ schema: this, value: originalValue }, ...(opts.from || [])];
 
     endEarly = this._option('abortEarly', opts);
     recursive = this._option('recursive', opts);
@@ -149,6 +145,9 @@ inherits(ObjectSchema, MixedSchema, {
           return value;
         }
 
+        from = originalValue
+          ? from
+          : [...from].splice(0, 1, { schema: this, value: originalValue });
         originalValue = originalValue || value;
 
         let validations = this._nodes.map(key => {

--- a/src/object.js
+++ b/src/object.js
@@ -147,7 +147,10 @@ inherits(ObjectSchema, MixedSchema, {
 
         from = originalValue
           ? from
-          : [...from].splice(0, 1, { schema: this, value: originalValue });
+          : [
+              { schema: this, value: originalValue || value },
+              ...(opts.from || []),
+            ];
         originalValue = originalValue || value;
 
         let validations = this._nodes.map(key => {

--- a/src/object.js
+++ b/src/object.js
@@ -146,7 +146,7 @@ inherits(ObjectSchema, MixedSchema, {
         }
 
         from = originalValue
-          ? from
+          ? [...from]
           : [
               { schema: this, value: originalValue || value },
               ...(opts.from || []),

--- a/src/object.js
+++ b/src/object.js
@@ -128,10 +128,16 @@ inherits(ObjectSchema, MixedSchema, {
     let originalValue =
       opts.originalValue != null ? opts.originalValue : _value;
 
+    let fromClosure = (scope, from) => () => {
+      return { value: originalValue, schema: scope, from };
+    };
+
+    let from = fromClosure(this, opts.from);
+
     endEarly = this._option('abortEarly', opts);
     recursive = this._option('recursive', opts);
 
-    opts = { ...opts, __validating: true, originalValue, parentSchema: this };
+    opts = { ...opts, __validating: true, originalValue, from };
 
     return MixedSchema.prototype._validate
       .call(this, _value, opts)
@@ -155,8 +161,8 @@ inherits(ObjectSchema, MixedSchema, {
           let innerOptions = {
             ...opts,
             path,
+            from,
             parent: value,
-            parentSchema: this,
             originalValue: originalValue[key],
           };
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -484,9 +484,7 @@ describe('Mixed Types ', () => {
   });
 
   it('tests should be able to access nested parent', async () => {
-    let calledFirst = false;
-    let calledThird = false;
-
+    let finalFrom,finalOptions;
     let testFixture = {
       firstField: 'test',
       second: [
@@ -502,14 +500,8 @@ describe('Mixed Types ', () => {
     let third = object({
       thirdField: mixed().test({
         test() {
-          calledThird = true;
-
-          this.from[0].value.should.eql(testFixture.second[this.options.index]);
-          this.from[0].schema.should.equal(third);
-
-          this.from[1].value.should.equal(testFixture);
-          this.from[1].schema.should.equal(first);
-
+          finalFrom = this.from;
+          finalOptions = this.options;
           return true;
         },
       }),
@@ -518,20 +510,17 @@ describe('Mixed Types ', () => {
     let second = array().of(third);
 
     let first = object({
-      firstField: mixed().test({
-        test() {
-          calledFirst = true;
-          this.from[0].value.should.equal(testFixture);
-          this.from[0].schema.should.equal(first);
-          return true;
-        },
-      }),
+      firstField: mixed(),
       second,
     });
 
     await first.validate(testFixture);
-    calledFirst.should.equal(true);
-    calledThird.should.equal(true);
+
+    finalFrom[0].value.should.eql(testFixture.second[finalOptions.index]);
+    finalFrom[0].schema.should.equal(third);
+    finalFrom[1].value.should.equal(testFixture);
+    finalFrom[1].schema.should.equal(first);
+
   });
 
   it('tests can return an error', () => {

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -461,7 +461,7 @@ describe('Mixed Types ', () => {
     let called = false;
     let inst = object({
       other: mixed(),
-      test: string().test({
+      test: object().test({
         message: 'invalid',
         exclusive: true,
         name: 'max',

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -485,51 +485,44 @@ describe('Mixed Types ', () => {
 
   it('tests should be able to access nested parent', async () => {
     let calledFirst = false;
-    let calledSecond = false;
     let calledThird = false;
 
     let testFixture = {
       firstField: 'test',
-      second: {
-        secondField: 'test2',
-        third: {
+      second: [
+        {
           thirdField: 'test3',
         },
-      },
+        {
+          thirdField: 'test4',
+        },
+      ],
     };
 
     let third = object({
       thirdField: mixed().test({
         test() {
           calledThird = true;
-          this.from[0].value.should.equal(testFixture.second.third);
+
+          // I want to do something like this,
+          // this.resolve(ref(this.path),this.from[1].value);
+          // OR probably preferably
+          // this.from[1].resolve(ref(this.path))
+          // but I can't get it working :( ...help?
+
+          // so I added an "index" option to array test options to make this test make sense
+          this.from[0].value.should.eql(testFixture.second[this.options.index]);
           this.from[0].schema.should.equal(third);
-
-          this.from[1].value.should.equal(testFixture.second);
-          this.from[1].schema.should.equal(second);
-
-          this.from[2].value.should.equal(testFixture);
-          this.from[2].schema.should.equal(first);
-
-          return true;
-        },
-      }),
-    });
-
-    let second = object({
-      secondField: mixed().test({
-        test() {
-          calledSecond = true;
-          this.from[0].value.should.equal(testFixture.second);
-          this.from[0].schema.should.equal(second);
 
           this.from[1].value.should.equal(testFixture);
           this.from[1].schema.should.equal(first);
+
           return true;
         },
       }),
-      third,
     });
+
+    let second = array().of(third);
 
     let first = object({
       firstField: mixed().test({
@@ -545,7 +538,6 @@ describe('Mixed Types ', () => {
 
     await first.validate(testFixture);
     calledFirst.should.equal(true);
-    calledSecond.should.equal(true);
     calledThird.should.equal(true);
   });
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -487,6 +487,7 @@ describe('Mixed Types ', () => {
     let calledFirst = false;
     let calledSecond = false;
     let calledThird = false;
+
     let testFixture = {
       firstField: 'test',
       second: {
@@ -501,24 +502,14 @@ describe('Mixed Types ', () => {
       thirdField: mixed().test({
         test() {
           calledThird = true;
-          this.from().schema.should.equal(third);
-          this.from().value.should.equal(testFixture.second.third);
+          this.from[0].value.should.equal(testFixture.second.third);
+          this.from[0].schema.should.equal(third);
 
-          this.from()
-            .from()
-            .schema.should.equal(second);
-          this.from()
-            .from()
-            .value.should.equal(testFixture.second);
+          this.from[1].value.should.equal(testFixture.second);
+          this.from[1].schema.should.equal(second);
 
-          this.from()
-            .from()
-            .from()
-            .schema.should.equal(first);
-          this.from()
-            .from()
-            .from()
-            .value.should.equal(testFixture);
+          this.from[2].value.should.equal(testFixture);
+          this.from[2].schema.should.equal(first);
 
           return true;
         },
@@ -529,15 +520,11 @@ describe('Mixed Types ', () => {
       secondField: mixed().test({
         test() {
           calledSecond = true;
-          this.from().schema.should.equal(second);
-          this.from().value.should.equal(testFixture.second);
+          this.from[0].value.should.equal(testFixture.second);
+          this.from[0].schema.should.equal(second);
 
-          this.from()
-            .from()
-            .schema.should.equal(first);
-          this.from()
-            .from()
-            .value.should.equal(testFixture);
+          this.from[1].value.should.equal(testFixture);
+          this.from[1].schema.should.equal(first);
           return true;
         },
       }),
@@ -548,8 +535,8 @@ describe('Mixed Types ', () => {
       firstField: mixed().test({
         test() {
           calledFirst = true;
-          this.from().schema.should.equal(first);
-          this.from().value.should.equal(testFixture);
+          this.from[0].value.should.equal(testFixture);
+          this.from[0].schema.should.equal(first);
           return true;
         },
       }),

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -504,13 +504,6 @@ describe('Mixed Types ', () => {
         test() {
           calledThird = true;
 
-          // I want to do something like this,
-          // this.resolve(ref(this.path),this.from[1].value);
-          // OR probably preferably
-          // this.from[1].resolve(ref(this.path))
-          // but I can't get it working :( ...help?
-
-          // so I added an "index" option to array test options to make this test make sense
           this.from[0].value.should.eql(testFixture.second[this.options.index]);
           this.from[0].schema.should.equal(third);
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -461,7 +461,7 @@ describe('Mixed Types ', () => {
     let called = false;
     let inst = object({
       other: mixed(),
-      test: object().test({
+      test: mixed().test({
         message: 'invalid',
         exclusive: true,
         name: 'max',

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -484,6 +484,39 @@ describe('Mixed Types ', () => {
     called.should.equal(true);
   });
 
+  it('tests should be called with the correct parentSchema', async () => {
+    let third = object({
+      thirdField: mixed().test({
+        test() {
+          this.parentSchema.should.equal(third);
+          return true;
+        },
+      }),
+    });
+
+    let second = object({
+      secondField: mixed().test({
+        test() {
+          this.parentSchema.should.equal(second);
+          return true;
+        },
+      }),
+      third,
+    });
+
+    let first = object({
+      firstField: mixed().test({
+        test() {
+          this.parentSchema.should.equal(first);
+          return true;
+        },
+      }),
+      second,
+    });
+
+    await first.validate({});
+  });
+
   it('tests can return an error', () => {
     let inst = mixed().test({
       message: 'invalid ${path}',

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -461,11 +461,12 @@ describe('Mixed Types ', () => {
     let called = false;
     let inst = object({
       other: mixed(),
-      test: mixed().test({
+      test: string().test({
         message: 'invalid',
         exclusive: true,
         name: 'max',
         test() {
+          this.parentSchema.should.equal(inst);
           this.path.should.equal('test');
           this.parent.should.eql({ other: 5, test: 'hi' });
           this.options.context.should.eql({ user: 'jason' });


### PR DESCRIPTION
I made a terrible attempt at this PR earlier. This should do it.

This resolves #551 and adds the capability to help with #553. 