### PR TITLE
fix: synchronous conditional object validation with unknown dependencies

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -12,8 +12,11 @@ import sortByKeyOrder from './util/sortByKeyOrder';
 import inherits from './util/inherits';
 import makePath from './util/makePath';
 import runValidations, { propagateErrors } from './util/runValidations';
+import { SynchronousPromise } from 'synchronous-promise';
 
 let isObject = obj => Object.prototype.toString.call(obj) === '[object Object]';
+
+let promise = sync => (sync ? SynchronousPromise : Promise);
 
 function unknown(ctx, value) {
   let known = Object.keys(ctx.fields);
@@ -167,7 +170,7 @@ inherits(ObjectSchema, MixedSchema, {
             return field.validate(value[key], innerOptions);
           }
 
-          return Promise.resolve(true);
+          return promise(sync).resolve(true);
         });
 
         return runValidations({

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -43,3 +43,20 @@ export let validateAll = (inst, { valid = [], invalid = [] }) => {
     });
   }
 };
+
+export function ensureSync(fn) {
+  let run = false;
+  let resolve = t => {
+    if (!run) return t;
+    throw new Error('Did not execute synchronously');
+  };
+  let err = t => {
+    if (!run) throw t;
+    throw new Error('Did not execute synchronously');
+  };
+
+  let result = fn().then(resolve, err);
+
+  run = true;
+  return result;
+}

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -1,34 +1,18 @@
 import {
   array,
-  mixed,
-  string,
-  number,
-  object,
-  ref,
-  reach,
   bool,
   lazy,
+  mixed,
+  number,
+  object,
+  reach,
+  ref,
+  string,
   ValidationError,
 } from '../src';
+import { ensureSync } from './helpers';
 
 let noop = () => {};
-
-function ensureSync(fn) {
-  let run = false;
-  let resolve = t => {
-    if (!run) return t;
-    throw new Error('Did not execute synchonously');
-  };
-  let err = t => {
-    if (!run) throw t;
-    throw new Error('Did not execute synchonously');
-  };
-
-  let result = fn().then(resolve, err);
-
-  run = true;
-  return result;
-}
 
 global.YUP_USE_SYNC &&
   it('[internal] normal methods should be running in sync Mode', async () => {


### PR DESCRIPTION
This PR fixes an issue where using `when` on an object with dependencies on properties that were not specified in the schema, caused the validation to become asynchronous even with `sync` set to true.