### PR TITLE
Fix insertion order when key matches partially

### DIFF
--- a/src/util/sortByKeyOrder.js
+++ b/src/util/sortByKeyOrder.js
@@ -1,7 +1,7 @@
 function findIndex(arr, err) {
   let idx = Infinity;
   arr.some((key, ii) => {
-    if (err.path.indexOf(key) !== -1) {
+    if (new RegExp(`^${err.path}$`).test(key)) {
       idx = ii;
       return true;
     }

--- a/test/object.js
+++ b/test/object.js
@@ -586,11 +586,12 @@ describe('Object types', () => {
     ]);
   });
 
-  it('should sort errors by insertion order', async () => {
+  fit('should sort errors by insertion order', async () => {
     let inst = object({
       // use `when` to make sure it is validated second
       foo: string().when('bar', () => string().min(5)),
       bar: string().required(),
+      barfoo: string().required(),
     });
 
     let err = await inst
@@ -600,6 +601,7 @@ describe('Object types', () => {
     err.errors.should.eql([
       'foo must be at least 5 characters',
       'bar is a required field',
+      'barfoo is a required field',
     ]);
   });
 

--- a/test/object.js
+++ b/test/object.js
@@ -586,7 +586,24 @@ describe('Object types', () => {
     ]);
   });
 
-  fit('should sort errors by insertion order', async () => {
+  it('should sort errors by insertion order', async () => {
+    let inst = object({
+      // use `when` to make sure it is validated second
+      foo: string().when('bar', () => string().min(5)),
+      bar: string().required(),
+    });
+
+    let err = await inst
+      .validate({ foo: 'foo' }, { abortEarly: false })
+      .should.rejected();
+
+    err.errors.should.eql([
+      'foo must be at least 5 characters',
+      'bar is a required field',
+    ]);
+  });
+
+  it('should sort errors by insertion order even when it matches partially', async () => {
     let inst = object({
       // use `when` to make sure it is validated second
       foo: string().when('bar', () => string().min(5)),


### PR DESCRIPTION
When a key of an object matches partially with another key, the lib is not respecting the defined order.

I created a new spec context to clarify and to prevent someone to misunderstand the `barfoo` key and delete it. Pls, let me know if you don't see a need for that.