### PR TITLE
feat: Add defined() validation to mix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ json separate from validating it, via the `cast` method.
     - [`mixed.nullable(isNullable: boolean = true): Schema`](#mixednullableisnullable-boolean--true-schema)
     - [`mixed.required(message?: string | function): Schema`](#mixedrequiredmessage-string--function-schema)
     - [`mixed.notRequired(): Schema`](#mixednotrequired-schema)
+    - [`mixed.defined(): Schema`](#mixeddefined-schema)
     - [`mixed.typeError(message: string): Schema`](#mixedtypeerrormessage-string-schema)
     - [`mixed.oneOf(arrayOfValues: Array<any>, message?: string | function): Schema` Alias: `equals`](#mixedoneofarrayofvalues-arrayany-message-string--function-schema-alias-equals)
     - [`mixed.notOneOf(arrayOfValues: Array<any>, message?: string | function)`](#mixednotoneofarrayofvalues-arrayany-message-string--function)
@@ -565,6 +566,10 @@ Mark the schema as required. All field values apart from `undefined` and `null` 
 #### `mixed.notRequired(): Schema`
 
 Mark the schema as not required. Passing `undefined` as value will not fail validation.
+
+#### `mixed.defined(): Schema`
+
+Mark the schema as required but nullable. All field values apart from `undefined` meet this requirement.
 
 #### `mixed.typeError(message: string): Schema`
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -20,6 +20,7 @@ export let mixed = {
 
     return msg;
   },
+  defined: '${path} must be defined',
 };
 
 export let string = {

--- a/src/mixed.js
+++ b/src/mixed.js
@@ -540,6 +540,17 @@ const proto = (SchemaType.prototype = {
         ),
     };
   },
+
+  defined(message = locale.defined) {
+    return this.nullable().test({
+      message,
+      name: 'defined',
+      exclusive: true,
+      test(value) {
+        return value !== undefined;
+      },
+    });
+  },
 });
 
 for (const method of ['validate', 'validateSync'])

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -930,4 +930,41 @@ describe('Mixed Types ', () => {
       },
     });
   });
+
+  describe('defined', () => {
+    it('should fail when value is undefined', async () => {
+      let inst = object({
+        prop: string().defined(),
+      });
+
+      await inst
+        .validate({})
+        .should.be.rejected()
+        .then(function(err) {
+          err.message.should.equal('prop must be defined');
+        });
+    });
+
+    it('should pass when value is null', async () => {
+      let inst = object({
+        prop: string().defined(),
+      });
+
+      await inst
+        .isValid({ prop: null })
+        .should.eventually()
+        .equal(true);
+    });
+
+    it('should pass when value is not undefined nor null', async () => {
+      let inst = object({
+        prop: string().defined(),
+      });
+
+      await inst
+        .isValid({ prop: 'prop value' })
+        .should.eventually()
+        .equal(true);
+    });
+  });
 });


### PR DESCRIPTION
After seeing this comment https://github.com/jquense/yup/issues/153#issuecomment-349679982 in an issue about the error when mixing `required` with `nullable` I thought it would be nice to have this validation.