### PR TITLE
[mixed] Added parameter "isOwnOptionForced" to strict method, that forces usage of strict() that allows to override strict coming from object schema

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -58,6 +58,7 @@ export default function SchemaType(options = {}) {
   this._deps = [];
   this._conditions = [];
   this._options = { abortEarly: true, recursive: true };
+  this._forcedOwnOptions = [];
   this._exclusive = Object.create(null);
 
   this._whitelist = new RefSet();
@@ -327,9 +328,12 @@ const proto = (SchemaType.prototype = {
     return next;
   },
 
-  strict(isStrict = true) {
+  strict(isStrict = true, isOwnOptionForced = false) {
     var next = this.clone();
     next._options.strict = isStrict;
+    if (isOwnOptionForced) {
+      next._forcedOwnOptions.push('strict');
+    }
     return next;
   },
 
@@ -523,6 +527,10 @@ const proto = (SchemaType.prototype = {
   },
 
   _option(key, overrides) {
+    if (this._forcedOwnOptions.indexOf(key) !== -1 && has(this._options, key)) {
+      return this._options[key];
+    }
+
     return has(overrides, key) ? overrides[key] : this._options[key];
   },
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -930,4 +930,99 @@ describe('Mixed Types ', () => {
       },
     });
   });
+
+  describe('strict in object shape', () => {
+    it('should reject if number member in object is string', async () => {
+      const schema = object({
+        numberField: number().strict(true),
+      });
+      const value = {
+        numberField: '25',
+      };
+
+      await schema.validateAt('numberField', value).should.be.rejected();
+    });
+
+    it('should accept if number member in object passed correctly', async () => {
+      const schema = object({
+        numberField: number().strict(true),
+      });
+      const value = {
+        numberField: 25,
+      };
+
+      await schema.validateAt('numberField', value).should.be.fulfilled();
+    });
+
+    it('should accept if number member in object passed as string and strict is false using strict()', async () => {
+      const schema = object({
+        numberField: number().strict(false),
+      });
+      const value = {
+        numberField: '25',
+      };
+
+      await schema.validateAt('numberField', value).should.be.fulfilled();
+    });
+
+    it('should accept if number member in object passed as string and strict is false using options', async () => {
+      const schema = object({
+        numberField: number(),
+      });
+      const value = {
+        numberField: '25',
+      };
+
+      await schema
+        .validateAt('numberField', value, { strict: false })
+        .should.be.fulfilled();
+    });
+
+    it('should reject if number member in object passed as string and strict is true using options', async () => {
+      const schema = object({
+        numberField: number(),
+      });
+      const value = {
+        numberField: '25',
+      };
+
+      await schema
+        .validateAt('numberField', value, { strict: true })
+        .should.be.rejected();
+    });
+
+    it(
+      'should reject if number member in object passed as string and strict is true using options, ' +
+        'even if strict(false) has been called on field',
+      async () => {
+        const schema = object({
+          numberField: number().strict(false),
+        });
+        const value = {
+          numberField: '25',
+        };
+
+        await schema
+          .validateAt('numberField', value, { strict: true })
+          .should.be.rejected();
+      },
+    );
+
+    it(
+      'should accept if number member in object passed as string and strict is true using options, ' +
+        'but if strict(false, true) has been called on field',
+      async () => {
+        const schema = object({
+          numberField: number().strict(false, true),
+        });
+        const value = {
+          numberField: '25',
+        };
+
+        await schema
+          .validateAt('numberField', value, { strict: true })
+          .should.be.fulfilled();
+      },
+    );
+  });
 });


### PR DESCRIPTION
This pull request is done for cases when some transformations are needed before validating objects. 

Now object fields must have proper type before validation will even start that creates an obligation for a caller to prepare object before validation. This can be a bit problematic when we are working with data from forms, that is represented in strings.

What do you think?