### PR TITLE
fix: unix epoc bug in date parser

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -21,7 +21,8 @@ function DateSchema() {
       if (this.isType(value)) return value;
 
       value = isoParse(value);
-      return value ? new Date(value) : invalidDate;
+      // 0 is a valid timestamp equivalent to 1970-01-01T00:00:00Z(unix epoch)
+      return value > -1 ? new Date(value) : invalidDate;
     });
   });
 }


### PR DESCRIPTION
Hopefully this fixes #234 and doesn't introduce any new buggy conditions.

I have modified return `value ? new Date(value) : invalidDate;` to `return value > -1 ? new Date(value) : invalidDate;` keeping in mind any valid values will be greater than -1, (i.e 0 or above) and the invalid value like `NaN` doesn't satisfy `> -1` condition.