### PR TITLE
Fix array path resolve for descendants

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -47,12 +47,10 @@ inherits(ArraySchema, MixedSchema, {
 
     let isChanged = false;
     const castArray = value.map((v, idx) => {
-      var path = makePath`${_opts.path}[${idx}]`;
-      var innerOptions = {
+      const castElement = this._subType.cast(v, {
         ..._opts,
-        path,
-      };
-      const castElement = this._subType.cast(v, innerOptions);
+        path: makePath`${_opts.path}[${idx}]`,
+      });
       if (castElement !== v) {
         isChanged = true;
       }

--- a/src/array.js
+++ b/src/array.js
@@ -46,8 +46,13 @@ inherits(ArraySchema, MixedSchema, {
     if (!this._typeCheck(value) || !this._subType) return value;
 
     let isChanged = false;
-    const castArray = value.map(v => {
-      const castElement = this._subType.cast(v, _opts);
+    const castArray = value.map((v, idx) => {
+      var path = makePath`${_opts.path}[${idx}]`;
+      var innerOptions = {
+        ..._opts,
+        path,
+      };
+      const castElement = this._subType.cast(v, innerOptions);
       if (castElement !== v) {
         isChanged = true;
       }

--- a/test/array.js
+++ b/test/array.js
@@ -175,4 +175,19 @@ describe('Array types', () => {
 
     inst.cast(null).should.eql([]);
   });
+
+  it('should pass resolved path to descendants', async () => {
+    let value = ['2', '3'];
+    let expectedPaths = ['[0]', '[1]'];
+
+    let itemSchema = string().when([], function(_, context) {
+      let path = context.path || '';
+      path.should.be.oneOf(expectedPaths);
+      return string().required();
+    });
+
+    await array()
+      .of(itemSchema)
+      .validate(value);
+  });
 });


### PR DESCRIPTION
At the moment during casting process Array type passes the field path to sub items without resolving it according to sub item array index.
The path is exposed to end consumer as part of context in conditional validation `when` (could be somewhere else).
If conditional validation relies on context path - this behaviour will lead to bugs.