### PR TITLE
Look up default error messages for custom validations in Locale

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -1,8 +1,7 @@
 import has from 'lodash/has';
 import cloneDeepWith from 'lodash/cloneDeepWith';
 import toArray from 'lodash/toArray';
-
-import { mixed as locale } from './locale';
+import globalLocale, { mixed as locale } from './locale';
 import Condition from './Condition';
 import runValidations from './util/runValidations';
 import prependDeep from './util/prependDeep';
@@ -394,7 +393,15 @@ const proto = (SchemaType.prototype = {
       opts = { name: args[0], message: args[1], test: args[2] };
     }
 
-    if (opts.message === undefined) opts.message = locale.default;
+    if (opts.message === undefined) {
+      if (globalLocale[this._type] && globalLocale[this._type][opts.name]) {
+        opts.message = globalLocale[this._type][opts.name];
+      } else if (locale[opts.name]) {
+        opts.message = locale[opts.name];
+      } else {
+        opts.message = locale.default;
+      }
+    }
 
     if (typeof opts.test !== 'function')
       throw new TypeError('`test` is a required parameters');

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -9,6 +9,7 @@ import {
   ref,
   string,
   ValidationError,
+  setLocale,
 } from '../src';
 import { ensureSync } from './helpers';
 
@@ -332,6 +333,26 @@ describe('Mixed Types ', () => {
     inst.tests.length.should.equal(1);
     inst.tests[0].OPTIONS.test.should.equal(noop);
     inst.tests[0].OPTIONS.message.should.equal('${path} is invalid');
+  });
+
+  it('should search locale for default message for tests', async () => {
+    const locale = require('../src/locale').default;
+    const dict = {
+      mixed: {
+        myTestWithLocale: 'Fallback error message',
+      },
+    };
+
+    setLocale(dict);
+    try {
+      let inst = mixed().test('myTestWithLocale', () => false);
+
+      await inst
+        .validate('foo')
+        .should.be.rejectedWith(ValidationError, 'Fallback error message');
+    } finally {
+      setLocale(locale);
+    }
   });
 
   it('should fallback to default message', async () => {

--- a/test/string.js
+++ b/test/string.js
@@ -1,6 +1,13 @@
 import * as TestHelpers from './helpers';
 
-import { string, number, object, ref } from '../src';
+import {
+  string,
+  number,
+  object,
+  ref,
+  setLocale,
+  ValidationError,
+} from '../src';
 
 describe('String types', () => {
   describe('casting', () => {
@@ -362,5 +369,48 @@ describe('String types', () => {
         .should.eventually()
         .equal(false),
     ]);
+  });
+
+  it('should use string locale to locate default test messages', function() {
+    const locale = require('../src/locale').default;
+    const dict = {
+      mixed: {
+        myTestWithLocale: 'Wrong error message',
+      },
+      string: {
+        myTestWithLocale: 'Right error message',
+      },
+    };
+
+    setLocale(dict);
+    try {
+      let inst = string().test('myTestWithLocale', () => false);
+
+      return inst
+        .validate('foo')
+        .should.be.rejectedWith(ValidationError, 'Right error message');
+    } finally {
+      setLocale(locale);
+    }
+  });
+
+  it('should use mixed locale when string locale contains no default test message', function() {
+    const locale = require('../src/locale').default;
+    const dict = {
+      mixed: {
+        myTestWithLocale: 'Right error message',
+      },
+    };
+
+    setLocale(dict);
+    try {
+      let inst = string().test('myTestWithLocale', () => false);
+
+      return inst
+        .validate('foo')
+        .should.be.rejectedWith(ValidationError, 'Right error message');
+    } finally {
+      setLocale(locale);
+    }
   });
 });


### PR DESCRIPTION
When a custom validation is defined by invoking `mixed().test('myCustomValidation', () => {...})`, yup checks the locale for a field matching the test name.

This allows us to write libraries of new validations while keeping control of messages in the client code.

For example, I could in a library

```
// ./node_modules/yup-extensions/index.js
import { addMethod, string } from yup;

addMethod(string, 'mustNotContain', function(stringToExclude, message) {
  return this.test({
    name: 'mustNotContain',
    test: (value) => value.indexOf(stringToExclude) === -1,
    message: message,
    params: {
      mustNotContain: stringToExclude
    }
  })
})
```

And this library could be used by a client as follows:

```
// clientCode.js

import { setLocale, string } from yup;
import 'yup-extensions';

setLocale({
  string: {
    required: "Please enter a value for ${path}",
    mustNotContain: "${path} must not contain '${mustNotContain}'"
  }
})

const validator = string()
  .required()
  .mustNotContain("<")
```

This way, the client need not worry if the method is part of the `yup` core library or a custom method: their interface for locale setting is identical.