### PR TITLE
locale: remove `number.notEqual`

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -39,7 +39,6 @@ export let number = {
   max: '${path} must be less than or equal to ${max}',
   lessThan: '${path} must be less than ${less}',
   moreThan: '${path} must be greater than ${more}',
-  notEqual: '${path} must be not equal to ${notEqual}',
   positive: '${path} must be a positive number',
   negative: '${path} must be a negative number',
   integer: '${path} must be an integer',


### PR DESCRIPTION
It looks like it was removed in [this commit](https://github.com/jquense/yup/commit/061e590bc305dbf6dafd14a20bc71d92fd42cd4a#diff-a8628b7684fb33ab3e2921b101c004ab). Looks like a description of reasoning is in [this comment](https://github.com/jquense/yup/pull/63#issuecomment-336444456) from the original PR.