### PR TITLE
Adds moreThan and lessThan to date validation (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ json separate from validating it, via the `cast` method.
   - [date](#date)
     - [`date.min(limit: Date | string | Ref, message?: string | function): Schema`](#dateminlimit-date--string--ref-message-string--function-schema)
     - [`date.max(limit: Date | string | Ref, message?: string | function): Schema`](#datemaxlimit-date--string--ref-message-string--function-schema)
+    - [`date.lessThan(limit: Date | string | Ref, message?: string | function): Schema`](#datelessthanlimit-date--string--ref-message-string--function-schema)
+    - [`date.moreThan(limit: Date | string | Ref, message?: string | function): Schema`](#datemorethanlimit-date--string--ref-message-string--function-schema)
   - [array](#array)
     - [`array.of(type: Schema): Schema`](#arrayoftype-schema-schema)
     - [`array.required(message?: string | function): Schema`](#arrayrequiredmessage-string--function-schema)
@@ -977,6 +979,16 @@ and use the result as the limit.
 #### `date.max(limit: Date | string | Ref, message?: string | function): Schema`
 
 Set the maximum date allowed, When a string is provided it will attempt to cast to a date first
+and use the result as the limit.
+
+#### `date.lessThan(limit: Date | string | Ref, message?: string | function): Schema`
+
+Value must be less than `limit`. When a string is provided it will attempt to cast to a date first
+and use the result as the limit.
+
+#### `date.moreThan(limit: Date | string | Ref, message?: string | function): Schema`
+
+Value must be more than `limit`. When a string is provided it will attempt to cast to a date first
 and use the result as the limit.
 
 ### array

--- a/src/date.js
+++ b/src/date.js
@@ -54,6 +54,50 @@ inherits(DateSchema, MixedSchema, {
     });
   },
 
+  lessThan(lessThan, message = locale.lessThan) {
+    var limit = lessThan;
+
+    if (!Ref.isRef(limit)) {
+      limit = this.cast(lessThan);
+      if (!this._typeCheck(limit))
+        throw new TypeError(
+          '`lessThan` must be a Date or a value that can be `cast()` to a Date',
+        );
+    }
+
+    return this.test({
+      message,
+      name: 'lessThan',
+      exclusive: true,
+      params: { lessThan },
+      test(value) {
+        return isAbsent(value) || value < this.resolve(limit);
+      },
+    });
+  },
+
+  moreThan(moreThan, message = locale.moreThan) {
+    var limit = moreThan;
+
+    if (!Ref.isRef(limit)) {
+      limit = this.cast(moreThan);
+      if (!this._typeCheck(limit))
+        throw new TypeError(
+          '`moreThan` must be a Date or a value that can be `cast()` to a Date',
+        );
+    }
+
+    return this.test({
+      message,
+      name: 'moreThan',
+      exclusive: true,
+      params: { moreThan },
+      test(value) {
+        return isAbsent(value) || value > this.resolve(limit);
+      },
+    });
+  },
+
   max(max, message = locale.max) {
     var limit = max;
 

--- a/test/date.js
+++ b/test/date.js
@@ -158,4 +158,108 @@ describe('Date types', () => {
         .equal(false),
     ]);
   });
+
+  it('should check LESSTHAN correctly', () => {
+    var lessThan = new Date(2014, 7, 15),
+      invalid = new Date(2014, 9, 15),
+      valid = new Date(2014, 5, 15);
+    (function() {
+      date().lessThan('hello');
+    }.should.throw(TypeError));
+    (function() {
+      date().lessThan(ref('$foo'));
+    }.should.not.throw());
+
+    return Promise.all([
+      date()
+        .lessThan(lessThan)
+        .isValid(valid)
+        .should.eventually()
+        .equal(true),
+      date()
+        .lessThan(lessThan)
+        .isValid(invalid)
+        .should.eventually()
+        .equal(false),
+      date()
+        .lessThan(lessThan)
+        .isValid(lessThan)
+        .should.eventually()
+        .equal(false),
+      date()
+        .lessThan(lessThan)
+        .nullable(true)
+        .isValid(null)
+        .should.eventually()
+        .equal(true),
+
+      date()
+        .lessThan(ref('$foo'))
+        .isValid(valid, { context: { foo: lessThan } })
+        .should.eventually()
+        .equal(true),
+      date()
+        .lessThan(ref('$foo'))
+        .isValid(invalid, { context: { foo: lessThan } })
+        .should.eventually()
+        .equal(false),
+      date()
+        .lessThan(ref('$foo'))
+        .isValid(lessThan, { context: { foo: lessThan } })
+        .should.eventually()
+        .equal(false),
+    ]);
+  });
+
+  it('should check MORETHAN correctly', () => {
+    var moreThan = new Date(2014, 7, 15),
+      invalid = new Date(2014, 5, 15),
+      valid = new Date(2014, 9, 15);
+    (function() {
+      date().moreThan('hello');
+    }.should.throw(TypeError));
+    (function() {
+      date().moreThan(ref('$foo'));
+    }.should.not.throw());
+
+    return Promise.all([
+      date()
+        .moreThan(moreThan)
+        .isValid(valid)
+        .should.eventually()
+        .equal(true),
+      date()
+        .moreThan(moreThan)
+        .isValid(invalid)
+        .should.eventually()
+        .equal(false),
+      date()
+        .moreThan(moreThan)
+        .isValid(moreThan)
+        .should.eventually()
+        .equal(false),
+      date()
+        .moreThan(moreThan)
+        .nullable(true)
+        .isValid(null)
+        .should.eventually()
+        .equal(true),
+
+      date()
+        .moreThan(ref('$foo'))
+        .isValid(valid, { context: { foo: moreThan } })
+        .should.eventually()
+        .equal(true),
+      date()
+        .moreThan(ref('$foo'))
+        .isValid(invalid, { context: { foo: moreThan } })
+        .should.eventually()
+        .equal(false),
+      date()
+        .moreThan(ref('$foo'))
+        .isValid(moreThan, { context: { foo: moreThan } })
+        .should.eventually()
+        .equal(false),
+    ]);
+  });
 });


### PR DESCRIPTION
While using this library I have found that it is useful to be able to validate dates with `moreThan` and `lessThan`.

Do you think that this would be a useful addition to the api?