### PR TITLE
Add ESM build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,14 @@
 {
   "presets": [["jason", { "debug": true, "ignoreBrowserslistConfig": true }]],
   "env": {
+    "modules": {
+      "presets": [
+        [
+          "jason",
+          { "debug": true, "ignoreBrowserslistConfig": true, "modules": false }
+        ]
+      ]
+    },
     "test": {
       "sourceMaps": "inline",
       "presets": [

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ $RECYCLE.BIN/
 
 # Ignore build files
 lib/
+es/

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release": "rollout",
     "build": "yarn build:commonjs && yarn build:modules && npm run toc",
     "build:commonjs": "babel src --out-dir lib --delete-dir-on-start",
-    "build:modules": "BABEL_ENV=modules babel src --out-dir es --delete-dir-on-start",
+    "build:modules": "babel src --out-dir es --delete-dir-on-start --env-name modules",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.28.0",
   "description": "Dead simple Object schema validation",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "runkitExampleFilename": "./runkit-example.js",
   "scripts": {
     "test": "npm run lint && npm run test-all -- --runInBand",
@@ -13,10 +14,13 @@
     "precommit": "lint-staged",
     "toc": "doctoc README.md --github",
     "release": "rollout",
-    "build": "babel src --out-dir lib --delete-dir-on-start && npm run toc",
+    "build": "yarn build:commonjs && yarn build:modules && npm run toc",
+    "build:commonjs": "babel src --out-dir lib --delete-dir-on-start",
+    "build:modules": "BABEL_ENV=modules babel src --out-dir es --delete-dir-on-start",
     "prepublishOnly": "npm run build"
   },
   "files": [
+    "es",
     "lib"
   ],
   "repository": {


### PR DESCRIPTION
Related to #311.

I see that there is a `rollup.config.js` that isn't hooked up yet. I guess that's probably the better way to go long term since people want a UMD build too (#100).

I did experiment and got Babel to output UMD too with another `.babelrc` entry for `"modules": "umd"` but it was multiple files so I'm not sure if that's what's wanted for UMD? I don't use UMD myself so I have no idea.

