### PR TITLE
Expose nullability of fields in schema description

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -533,6 +533,7 @@ const proto = (SchemaType.prototype = {
       type: next._type,
       meta: next._meta,
       label: next._label,
+      nullable: next._nullable,
       tests: next.tests
         .map(fn => ({ name: fn.OPTIONS.name, params: fn.OPTIONS.params }))
         .filter(

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -888,19 +888,22 @@ describe('Mixed Types ', () => {
       bar: string()
         .max(2)
         .meta({ input: 'foo' })
-        .label('str!'),
+        .label('str!')
+        .nullable(),
     }).describe();
 
     desc.should.eql({
       type: 'object',
       meta: undefined,
       label: undefined,
+      nullable: undefined,
       tests: [],
       fields: {
         foo: {
           type: 'array',
           meta: undefined,
           label: undefined,
+          nullable: undefined,
           tests: [
             {
               name: 'required',
@@ -911,6 +914,7 @@ describe('Mixed Types ', () => {
             type: 'number',
             meta: undefined,
             label: undefined,
+            nullable: undefined,
             tests: [
               {
                 name: 'integer',
@@ -922,6 +926,7 @@ describe('Mixed Types ', () => {
         bar: {
           type: 'string',
           label: 'str!',
+          nullable: true,
           tests: [{ name: 'max', params: { max: 2 } }],
           meta: {
             input: 'foo',


### PR DESCRIPTION
In our application, we have some helpers used to generate initial values given to formik forms, based on the yup schema.

Nullability is currently very hard to handle, because it is not exposed when calling `.describe()`. This will add nullable to the field description.