### PR TITLE
Add note about using compilerOptions.strict for TS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1304,3 +1304,7 @@ const fullPerson: Person = {
     birthDate: new Date(1976, 9, 5)
 };
 ```
+
+**A Note about the `strict` compiler option**:
+
+You'll have to specify `compilerOptions.strict = true` in your `tsconfig.json` or all members of any inferred type will be optional.


### PR DESCRIPTION
Had an issue on a recent project where having `strict=false` led to all fields marked optional:

```typescript
import * as yup from "yup";

const foo = yup.object({
  a: yup.string(),
  b: yup.string().nullable(),
});

type Foo = yup.InferType<typeof foo>;

/*
Foo incorrectly has a and b defined as optional when strict=false

type Foo = {
    a?: string;
    b?: string;
}
*/
```