### PR TITLE
isodate supports 1 & 2 digit years

### DIFF
--- a/src/util/isodate.js
+++ b/src/util/isodate.js
@@ -31,8 +31,8 @@ export default function parseIsoDate(date) {
     if (
       (struct[8] === undefined || struct[8] === '') &&
       (struct[9] === undefined || struct[9] === '')
-    )
-      timestamp = +new Date(
+    ) {
+      var parsedDate = new Date(
         struct[1],
         struct[2],
         struct[3],
@@ -41,22 +41,34 @@ export default function parseIsoDate(date) {
         struct[6],
         struct[7],
       );
-    else {
+
+      // Support 1 & 2 digit years
+      parsedDate.setFullYear(struct[1]);
+
+      timestamp = +parsedDate;
+    } else {
       if (struct[8] !== 'Z' && struct[9] !== undefined) {
         minutesOffset = struct[10] * 60 + struct[11];
 
         if (struct[9] === '+') minutesOffset = 0 - minutesOffset;
       }
 
-      timestamp = Date.UTC(
-        struct[1],
-        struct[2],
-        struct[3],
-        struct[4],
-        struct[5] + minutesOffset,
-        struct[6],
-        struct[7],
+      var parsedDate = new Date(
+        Date.UTC(
+          struct[1],
+          struct[2],
+          struct[3],
+          struct[4],
+          struct[5] + minutesOffset,
+          struct[6],
+          struct[7],
+        ),
       );
+
+      // Support 1 & 2 digit years
+      parsedDate.setUTCFullYear(struct[1]);
+
+      timestamp = +parsedDate;
     }
   } else timestamp = Date.parse ? Date.parse(date) : NaN;
 

--- a/test/date.js
+++ b/test/date.js
@@ -15,6 +15,8 @@ describe('Date types', () => {
     inst.cast('2016-08-10T11:32:19.012Z').should.eql(new Date(1470828739012));
     // Microsecond precision
     inst.cast('2016-08-10T11:32:19.2125Z').should.eql(new Date(1470828739212));
+    // Single digit years
+    inst.cast('0001-01-01T00:00:00.000Z').should.eql(new Date(-62135596800000));
   });
 
   it('should return invalid date for failed casts', function() {


### PR DESCRIPTION
This patch fixes a bug where 1 & 2 digit years are converted to the 1900's. Eg 75 becomes 1975. 

It is backwards compatible with IE8.