### PR TITLE
Update i18n doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ schema.cast({
 
 > If you're looking for an easily serializable DSL for yup schema, check out [yup-ast](https://github.com/WASD-Team/yup-ast)
 
-### Using a custom locale dictionary
+### Defining custom error messages
 
-Allows you to customize the default messages used by Yup, when no message is provided with a validation test.
-If any message is missing in the custom dictionary the error message will default to Yup's one.
+`setLocale` allows you to customize the default messages used by Yup, when no message is provided with a validation test.
+If any message is missing in the custom dictionary the error message will default to Yup's one. **`setLocale` must be called before you define your schema.**
 
 ```js
 import { setLocale } from 'yup';
@@ -193,6 +193,7 @@ schema.validate({ name: 'jimmy', age: 11 }).catch(function(err) {
   err.errors; // => ['Deve ser maior que 18']
 });
 ```
+### Using a custom locale dictionary
 
 If you need multi-language support, Yup has got you covered. The function `setLocale` accepts functions that can be used to generate error objects with translation keys and values. Just get this output and feed it into your favorite i18n library.
 


### PR DESCRIPTION
Currently doc is confusing. The pattern of calling  `setLocale` with hard written text or even `t('foobar')` is NOT meant for i18n, as it doesn't support language switching for instance.

The second pattern with using function that returns i18n objects (`{key:'foobar', values: {min}`) is the only right pattern for i18n.