### PR TITLE
Allow passing of function to .matches() options/message param

### DIFF
--- a/src/string.js
+++ b/src/string.js
@@ -77,6 +77,7 @@ inherits(StringSchema, MixedSchema, {
 
     if (options) {
       if (typeof options === 'string') message = options;
+      if (typeof options === 'function') message = options;
       if (typeof options === 'object') {
         ({ excludeEmptyString, message, name } = options);
       }

--- a/src/string.js
+++ b/src/string.js
@@ -76,10 +76,10 @@ inherits(StringSchema, MixedSchema, {
     let name;
 
     if (options) {
-      if (typeof options === 'string') message = options;
-      if (typeof options === 'function') message = options;
       if (typeof options === 'object') {
         ({ excludeEmptyString, message, name } = options);
+      } else {
+        message = options;
       }
     }
 


### PR DESCRIPTION
Came across issue #849 this morning. Hopefully this closes #849 