### PR TITLE
Bug: fix object bug when nested object has a property with strict

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -88,7 +88,7 @@ inherits(ObjectSchema, MixedSchema, {
     let innerOptions = {
       ...options,
       parent: intermediateValue,
-      __validating: false,
+      __validating: options.__validating || false,
     };
 
     let isChanged = false;

--- a/test/object.js
+++ b/test/object.js
@@ -146,6 +146,20 @@ describe('Object types', () => {
       err.message.should.match(/must be a `string` type/);
     });
 
+    it('should respect strict for nested object values', async () => {
+      inst = object({
+        obj: object({
+          field: string().strict(),
+        }),
+      });
+
+      let err = await inst
+        .validate({ obj: { field: 5 } })
+        .should.be.rejected();
+
+      err.message.should.match(/must be a `string` type/);
+    });
+
     it('should respect child schema with strict()', async () => {
       inst = object({
         field: number().strict(),


### PR DESCRIPTION
Closes #857 

This PR fix a bug when `strict` is used on nested objects and the cast still happens