### PR TITLE
Update readme to account for changes in types and add additional example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.29.0](https://github.com/jquense/yup/compare/v0.28.5...v0.29.0) (2020-05-15)
+
+
+### BREAKING CHANGES
+
+* the types ([@types/yup](https://www.npmjs.com/package/@types/yup)) have been updated to include `undefined` by default. TypeScript users can add `.defined()` to their schemas to account for this.
+
+
 ## [0.28.5](https://github.com/jquense/yup/compare/v0.28.4...v0.28.5) (2020-04-30)
 
 

--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,10 @@ import * as yup from 'yup';
 const personSchema = yup.object({
   firstName: yup
     .string()
+    // Here we use `defined` instead of `required` to more closely align with
+    // TypeScript. Both will have the same effect on the resulting type by
+    // excluding `undefined`, but `required` will also disallow other values
+    // such as empty strings.
     .defined(),
   nickName: yup
     .string()

--- a/README.md
+++ b/README.md
@@ -1300,10 +1300,10 @@ const personSchema = yup.object({
     .nullable(),
   gender: yup
     .mixed()
-    .defined()
     // Note `as const`: this types the array as `["male", "female", "other"]`
     // instead of `string[]`.
-    .oneOf(['male', 'female', 'other'] as const),
+    .oneOf(['male', 'female', 'other'] as const)
+    .defined(),
   email: yup
     .string()
     .nullable()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yup",
-  "version": "0.28.5",
+  "version": "0.29.0",
   "description": "Dead simple Object schema validation",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yup",
-  "version": "0.29.0",
+  "version": "0.28.5",
   "description": "Dead simple Object schema validation",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
Note: This is a draft PR because it should not be merged until DefinitelyTyped/DefinitelyTyped#44589 is merged.

- Removes the "Why does InferType not default to nonRequired()" since this is incorrect due to DefinitelyTyped/DefinitelyTyped#44589
- Adds `defined` calls to the `firstName` and `nickName` in the example
- Updates example and adds note for using `oneOf`` without using the generic type parameter of `mixed` (DefinitelyTyped/DefinitelyTyped#44573)
- Adds an example for how you might ensure that a schema conforms to an interface or type

**Note**: Does not change the version in package.json.