### PR TITLE
feat: export locale

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import ValidationError from './ValidationError';
 import reach from './util/reach';
 import isSchema from './util/isSchema';
 import setLocale from './setLocale';
+import locale from './locale';
 
 let boolean = bool;
 let ref = (key, options) => new Ref(key, options);
@@ -44,5 +45,6 @@ export {
   isSchema,
   addMethod,
   setLocale,
+  locale,
   ValidationError,
 };


### PR DESCRIPTION
This is useful for custom method. eg:

```js
import * as yup from 'yup'
import { isChineseMobilePhoneNumber } from '../utils'

yup.setLocale({
  string: {
    chineseMobilePhoneNumber: '${path} must be a Chinese mobile phone number'
  }
})

yup.addMethod(
  yup.string,
  'chineseMobilePhoneNumber',
  function (message = yup.locale.string.chineseMobilePhoneNumber) {
    return this.test(
      'chineseMobilePhoneNumber',
      message,
      isChineseMobilePhoneNumber
    )
  }
)
```