### PR TITLE
add info feature

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -98,14 +98,24 @@ const proto = (SchemaType.prototype = {
 
     // if the nested value is a schema we can skip cloning, since
     // they are already immutable
-    return cloneDeepWith(this, value => {
+    var info = this._info;
+    delete this._info;
+    var clone = cloneDeepWith(this, value => {
       if (isSchema(value) && value !== this) return value;
     });
+    clone._info = info;
+    return clone;
   },
 
   label(label) {
     var next = this.clone();
     next._label = label;
+    return next;
+  },
+
+  info(info) {
+    var next = this.clone();
+    next._info = info;
     return next;
   },
 
@@ -411,6 +421,7 @@ const proto = (SchemaType.prototype = {
     }
 
     if (opts.message === undefined) opts.message = locale.default;
+    opts._info = this._info;
 
     if (typeof opts.test !== 'function')
       throw new TypeError('`test` is a required parameters');

--- a/src/util/createValidation.js
+++ b/src/util/createValidation.js
@@ -32,6 +32,7 @@ export function createErrorFactory({
   label,
   resolve,
   originalValue,
+  _info,
   ...opts
 }) {
   return function createError({
@@ -45,6 +46,7 @@ export function createErrorFactory({
       value,
       originalValue,
       label,
+      _info,
       ...resolveParams(opts.params, params, resolve),
     };
 
@@ -56,7 +58,7 @@ export function createErrorFactory({
 }
 
 export default function createValidation(options) {
-  let { name, message, test, params } = options;
+  let { name, message, test, params, _info } = options;
 
   function validate({
     value,
@@ -82,6 +84,7 @@ export default function createValidation(options) {
       label,
       resolve,
       name,
+      _info,
     });
 
     let ctx = {


### PR DESCRIPTION
For now, it's impossible to do i18n when using `yup.setLocale`.

This PR add a method called `info` to eject `_info` property to `mixed`, and you can get `_info` from `message` function.

"info" is like context in GraphQL. (the context term has been used in yup, so I use info)
You can set info as any type of value.

With this PR, you can do i18n like the following
```js
yup.setLocale({
  number: {
    min: ({label, min, _info}) => {
      return _info.i18n("MinErrorMessage", { label, min });
    },
  },
});

const i18n = function() {
  return "localized message";
};

const schema = yup.object().shape({
  age: yup
    .number()
    .info({ i18n })
    .label("age")
    .min(10)
});

schema.validateSync({ age: 5 });
```
