### PR TITLE
Handle sparse array positions as undefined

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -84,6 +84,12 @@ inherits(ArraySchema, MixedSchema, {
 
         originalValue = originalValue || value;
 
+        // Populate sparse arrays positions with undefined
+        value = value.slice()
+        let len = value.length;
+        let idx = -1;
+        while (++idx < len) if (!(idx in value)) value[idx] = undefined;
+
         let validations = value.map((item, idx) => {
           var path = makePath`${options.path}[${idx}]`;
 

--- a/test/array.js
+++ b/test/array.js
@@ -202,4 +202,14 @@ describe('Array types', () => {
       .of(itemSchema)
       .validate(value);
   });
+
+  it('should treat sparse arrays empty spots as undefined', async () => {
+    let sparseArray = new Array(2);
+    sparseArray[1] = 1;
+    let value = await array().of(number()).validate(sparseArray);
+    // assert the sparse array position has been turned into a real position
+    expect(0 in sparseArray).to.be.false()
+    expect(0 in value).to.be.true()
+    value.should.eql([undefined, 1]);
+  });
 });


### PR DESCRIPTION
This fixes https://github.com/jquense/yup/issues/676

---

The is the source of the bug is here, but rather than adding a local fix, a better fix is proposed in this PR:

https://github.com/jquense/yup/blob/27b287ba0dd8981ddb330c28123b41d85c4c8853/src/util/runValidations.js#L38-L49

Here, `promises.map` is supposed to map fulfilled and rejected promises to the appropriate value object. However, `Array.map` does not iterate over the empty spots in sparse arrays:

![image](https://user-images.githubusercontent.com/202527/85545149-5935d700-b624-11ea-9aed-bff0e65c9f39.png)

The bug originates here:

https://github.com/jquense/yup/blob/27b287ba0dd8981ddb330c28123b41d85c4c8853/src/array.js#L87


Here, no validation will be generated for empty Array positions.


---



It seems reasonable for yup to transform empty array positions to undefined in its output. This fixes the bug, and is arguably what people expect when a sparse array is passed into yup.



