### PR TITLE
Handle sparse array positions as undefined V2

### DIFF
--- a/src/array.js
+++ b/src/array.js
@@ -84,8 +84,10 @@ inherits(ArraySchema, MixedSchema, {
 
         originalValue = originalValue || value;
 
-        let validations = value.map((item, idx) => {
-          var path = makePath`${options.path}[${idx}]`;
+        let validations = new Array(value.length);
+        for (let idx = 0; idx < value.length; idx++) {
+          let item = value[idx];
+          let path = makePath`${options.path}[${idx}]`;
 
           // object._validate note for isStrict explanation
           var innerOptions = {
@@ -97,10 +99,10 @@ inherits(ArraySchema, MixedSchema, {
             originalValue: originalValue[idx],
           };
 
-          if (innerType.validate) return innerType.validate(item, innerOptions);
-
-          return true;
-        });
+          validations[idx] = innerType.validate
+            ? innerType.validate(item, innerOptions)
+            : true;
+        }
 
         return runValidations({
           sync,

--- a/src/array.js
+++ b/src/array.js
@@ -84,6 +84,7 @@ inherits(ArraySchema, MixedSchema, {
 
         originalValue = originalValue || value;
 
+        // #950 Ensure that sparse array empty slots are validated
         let validations = new Array(value.length);
         for (let idx = 0; idx < value.length; idx++) {
           let item = value[idx];

--- a/test/array.js
+++ b/test/array.js
@@ -202,4 +202,20 @@ describe('Array types', () => {
       .of(itemSchema)
       .validate(value);
   });
+
+  it('should maintain array sparseness through validation', async () => {
+    let sparseArray = new Array(2);
+    sparseArray[1] = 1;
+    let value = await array().of(number()).validate(sparseArray);
+    expect(0 in sparseArray).to.be.false()
+    expect(0 in value).to.be.false()
+    // eslint-disable-next-line no-sparse-arrays
+    value.should.eql([,1]);
+  });
+
+  it('should validate empty slots in sparse array', async () => {
+    let sparseArray = new Array(2);
+    sparseArray[1] = 1;
+    await array().of(number().required()).isValid(sparseArray).should.become(false);
+  });
 });


### PR DESCRIPTION
Superseeds #949; Fixes #676

Yup validation no longer throws on sparse arrays:
```javascript
let schema = y.array(number())
let arr = []
arr[1] = 1
arr
// => [empty, 1]

// fixes TypeError: Cannot read property 'fulfilled' of undefined
schema.validate(arr, {
  abortEarly: false,
  context: {},
})
```
---

Yup required validation now treats empty slots in sparse arrays as missing:
```javascript
let schema = y.array(y.number().required())
let arr = []
arr[1] = 1
arr
// => [empty, 1]

await schema.isValid(arr) // false
await schema.compact().isValid(arr) // true
```

---

Yup preserves empty slots in sparse arrays when valid:
```javascript
let schema = y.array(y.number())
let arr = []
arr[1] = 1
arr
// => [empty, 1]

let value = await schema.validate(arr)

0 in value 
// => false
```