### PR TITLE
README: document interpolation with default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ schema.cast({
   createdOn: '2014-09-23T19:25:25Z',
 });
 // => { name: 'jimmy', age: 24, createdOn: Date }
+
+// interpolate with default values
+let schema = yup.object().shape({
+  count: yup.number().required().positive().integer(),
+  version: yup.string().default("v1")
+});
+schema.validateSync({ count: 1 });
+// => { version: 'v1', count: 1 }
 ```
 
 > If you're looking for an easily serializable DSL for yup schema, check out [yup-ast](https://github.com/WASD-Team/yup-ast)
@@ -387,6 +395,8 @@ Creates a new instance of the schema by combining two schemas. Only schemas of t
 Returns the value (a cast value if `isStrict` is `false`) if the value is valid, and returns the errors otherwise.
 This method is **asynchronous** and returns a Promise object, that is fulfilled with the value, or rejected
 with a `ValidationError`.
+
+The object returned by `validate()` contains defaults specified in the schema.
 
 The `options` argument is an object hash containing any schema options you may want to override
 (or specify for the first time).


### PR DESCRIPTION
I am new to yup and carefully read the documentation to understand what I need to do to i) validate a user-given object against a schema and also to ii) fill the user-given object with defaults set in the schema.

Based on what's in the README I couldn't explicitly find an answer for how to do ii). I then tried the obvious thing; inspecting the value returned by validation. Yes, that seems to be the way to go.

I think it's worth explicitly discussing this use case in the README. Feedback welcome.