### PR TITLE
feat: add default message to typeError from locale

### DIFF
--- a/src/mixed.js
+++ b/src/mixed.js
@@ -460,7 +460,7 @@ const proto = (SchemaType.prototype = {
     return next;
   },
 
-  typeError(message) {
+  typeError(message = locale.notType) {
     var next = this.clone();
 
     next._typeError = createValidation({
@@ -557,7 +557,7 @@ const proto = (SchemaType.prototype = {
 
     if (next._whitelist.size) description.oneOf = next._whitelist.describe();
     if (next._blacklist.size) description.notOneOf = next._blacklist.describe();
-    
+
     return description;
   },
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -146,23 +146,36 @@ describe('Mixed Types ', () => {
     expect(error.message).to.match(/My string is required/);
   });
 
-  it('should check types', async () => {
-    let inst = string()
-      .strict()
-      .typeError('must be a ${type}!');
+  describe('typeError', () => {
+    it('should check types', async () => {
+      let inst = string()
+        .strict()
+        .typeError('must be a ${type}!');
 
-    let error = await inst.validate(5).should.be.rejected();
+      let error = await inst.validate(5).should.be.rejected();
 
-    error.type.should.equal('typeError');
-    error.message.should.equal('must be a string!');
-    error.inner.length.should.equal(0);
+      error.type.should.equal('typeError');
+      error.message.should.equal('must be a string!');
+      error.inner.length.should.equal(0);
 
-    error = await inst.validate(5, { abortEarly: false }).should.be.rejected();
+      error = await inst.validate(5, { abortEarly: false }).should.be.rejected();
 
-    expect(error.type).to.not.exist();
-    error.message.should.equal('must be a string!');
-    error.inner.length.should.equal(1);
-  });
+      expect(error.type).to.not.exist();
+      error.message.should.equal('must be a string!');
+      error.inner.length.should.equal(1);
+    });
+
+    it('should fallback to default message', async () => {
+      let inst = string()
+        .strict()
+        .typeError();
+
+      let error = await inst.validate(5).should.be.rejected();
+
+      error.type.should.equal('typeError');
+      error.message.should.equal('this must be a `string` type, but the final value was: `5`.');
+    })
+  })
 
   it('should limit values', async () => {
     let inst = mixed().oneOf([5, 'hello']);


### PR DESCRIPTION
## Motivation
I couldn't find a way to override `typeError` message using a custom locale dictionary. It only works passing a default message to `typeError` as described here: #797