### PR TITLE
Mark & resolve stale issues automatically

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 3
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - bug
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true


### PR DESCRIPTION
So one thing that was annoying me a bit was the number of issues/PRs that were essentially "dead" (i.e. no response from the original author) or resolved but _not_ closed. I think adding stalebot (and reducing the number of those stale issues) will help to clarify what issues actually _are_ active.

The only thing you need to do after merging this PR is to go to https://github.com/apps/stale and install stalebot on this repo.

Happy coding!