### PR TITLE
Upgrades property-expr dependency to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@babel/runtime": "^7.10.5",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.11",
-    "property-expr": "^2.0.2",
+    "property-expr": "^2.0.4",
     "toposort": "^2.0.2"
   },
   "readme": "ERROR: No README data found!",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7227,10 +7227,10 @@ prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-property-expr@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.2.tgz#fff2a43919135553a3bc2fdd94bdb841965b2330"
-  integrity sha512-bc/5ggaYZxNkFKj374aLbEDqVADdYaLcFo8XBkishUWbaAdjlphaBFns9TvRA2pUseVL/wMFmui9X3IdNDU37g==
+property-expr@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
+  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes vulnerability issue described in https://github.com/jquense/yup/issues/1046.