### PR TITLE
Add method to allow empty array when using along .required()

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "sinon": "^9.0.3",
-    "sinon-chai": "^3.5.0"
+    "sinon-chai": "^3.5.0",
+    "synchronous-promise": "^2.0.14"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",

--- a/src/array.js
+++ b/src/array.js
@@ -17,6 +17,7 @@ function ArraySchema(type) {
   // "no subtype"
   this._subType = undefined;
   this.innerType = undefined;
+  this._emptyAllowed = false;
 
   this.withMutation(() => {
     this.transform(function (values) {
@@ -129,8 +130,17 @@ inherits(ArraySchema, MixedSchema, {
 
   _isPresent(value) {
     return (
-      MixedSchema.prototype._isPresent.call(this, value) && value.length > 0
+      MixedSchema.prototype._isPresent.call(this, value) &&
+      (this._emptyAllowed || value.length > 0)
     );
+  },
+
+  allowEmpty() {
+    var next = this.clone();
+
+    next._emptyAllowed = true;
+
+    return next;
   },
 
   of(schema) {

--- a/test/array.js
+++ b/test/array.js
@@ -98,6 +98,21 @@ describe('Array types', () => {
       castSpy.should.have.been.calledOnce();
       string.prototype._cast.restore();
     });
+
+    it('should not allow empty arrays if required is set', async () => {
+      await array().required().isValid([]).should.become(false);
+    });
+
+    it('should allow empty arrays if required is set along with allowEmpty', async () => {
+      await array().required().allowEmpty().isValid([]).should.become(true);
+
+      await array()
+        .of(number())
+        .allowEmpty()
+        .required()
+        .isValid([])
+        .should.become(true);
+    });
   });
 
   it('should respect abortEarly', () => {

--- a/test/object.js
+++ b/test/object.js
@@ -153,7 +153,7 @@ describe('Object types', () => {
       err.message.should.match(/must be a `string` type/);
     });
 
-    it.only('should respect child schema with strict()', async () => {
+    it('should respect child schema with strict()', async () => {
       inst = object({
         field: number().strict(),
       });
@@ -888,7 +888,7 @@ describe('Object types', () => {
     expect(inst.nullable().cast(null)).to.equal(null);
   });
 
-  xit('should handle invalid shapes better', async () => {
+  it('should handle invalid shapes better', async () => {
     var schema = object().shape({
       permissions: undefined,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8452,6 +8452,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synchronous-promise@^2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.14.tgz#86b3b3284ad8567b69dc0b2d51c6fd446ddc2d91"
+  integrity sha512-XassJA855Rbhsggr5Yr1sms+iDDzkmwfhqPJzl7Lq544+7fjo9NmCpetrvQc33S/HE1JnoI2zA3CLDxTQTpWHA==
+
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"


### PR DESCRIPTION
Proposed PR adds a method called ```allowEmpty``` that allows empty arrays to be valid when ```required``` is also set.

Example usage:

```ts
const schema = array().required().allowEmpty();
schema.isValidSync([]); // true
```

Also, added a missing test dependency and fixed object tests that had 2 typos.