### PR TITLE
Document the interface version of derived types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1314,7 +1314,12 @@ const personSchema = yup.object({
 You can derive the TypeScript type as follows:
 
 ```TypeScript
-type Person = yup.InferType<typeof personSchema>;
+interface Person extends yup.InferType<typeof personSchema> {};
+
+// You can also name it as a type, this is necessary for non-object schemas:
+type Person = yup.InferType<typeof personSchema> {};
+
+// Using the type variant can result in worse type info being presented by your tooling.
 ```
 
 Which is equivalent to the following TypeScript type alias:


### PR DESCRIPTION
Using `type Person = yup.InferType<typeof personSchema> {};` can result in verbose and unreadable type info being presented by your tooling, e.g. your text editor.

The suggested alternative fixes this and gives type info as expected.

**Here are some examples:**

> **Before:**
> 
> <img width="907" alt="Screen Shot 2020-10-23 at 11 54 35 pm" src="https://user-images.githubusercontent.com/971886/97026157-9d61c580-158b-11eb-97ae-72c269e8ceb1.png">
> 
>
> **After:**
> 
> <img width="807" alt="Screen Shot 2020-10-23 at 11 54 54 pm" src="https://user-images.githubusercontent.com/971886/97026205-ac487800-158b-11eb-9e53-e3bf2199e528.png">
> 

<br />

> **Before:**
> 
> <img width="587" alt="Screen Shot 2020-10-23 at 11 53 20 pm" src="https://user-images.githubusercontent.com/971886/97026320-d0a45480-158b-11eb-848d-16c51d4958c2.png">
> 
>
> **After:**
> 
> <img width="621" alt="Screen Shot 2020-10-23 at 11 53 34 pm" src="https://user-images.githubusercontent.com/971886/97026347-d8fc8f80-158b-11eb-8cfc-0179ff186a31.png">

<br />


> **Before:**
> 
> <img width="599" alt="Screen Shot 2020-10-23 at 11 52 38 pm" src="https://user-images.githubusercontent.com/971886/97026424-edd92300-158b-11eb-90bc-a3802cf331a8.png">
> 
> 
> **After:**
> 
> <img width="545" alt="Screen Shot 2020-10-23 at 11 52 51 pm" src="https://user-images.githubusercontent.com/971886/97026440-f29dd700-158b-11eb-8bde-d630f69d1183.png">

