### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "sinon": "^9.2.0",
-    "sinon-chai": "^3.5.0"
+    "sinon-chai": "^3.5.0",
+    "synchronous-promise": "^2.0.15"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.5",

--- a/src/locale.js
+++ b/src/locale.js
@@ -63,7 +63,7 @@ export let array = {
   max: '${path} field must have less than or equal to ${max} items',
 };
 
-export default {
+export default Object.assign(Object.create(null), {
   mixed,
   string,
   number,
@@ -71,4 +71,4 @@ export default {
   object,
   array,
   boolean,
-};
+});

--- a/test/object.js
+++ b/test/object.js
@@ -153,7 +153,7 @@ describe('Object types', () => {
       err.message.should.match(/must be a `string` type/);
     });
 
-    it.only('should respect child schema with strict()', async () => {
+    it('should respect child schema with strict()', async () => {
       inst = object({
         field: number().strict(),
       });

--- a/test/setLocale.js
+++ b/test/setLocale.js
@@ -23,4 +23,20 @@ describe('Custom locale', () => {
     const locale = require('../src/locale').default;
     expect(locale.string.email).to.equal('Invalid email');
   });
+
+  it('should not allow prototype pollution', () => {
+    const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
+
+    expect(() => setLocale(payload)).to.throw();
+
+    expect(payload).not.to.have.property('polluted');
+  });
+
+  it('should not pollute Object.prototype builtins', () => {
+    const payload = { toString: { polluted: 'oh no' } };
+
+    expect(() => setLocale(payload)).to.throw();
+
+    expect(Object.prototype.toString).not.to.have.property('polluted');
+  });
 });


### PR DESCRIPTION
https://huntr.dev/users/ljharb has fixed the Prototype Pollution vulnerability 🔨. ljharb has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/yup/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/yup/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-yup

### ⚙️ Description *

This uses a null object as the base locale data, so it doesn't *have* a prototype to pollute.

### 💻 Technical Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 🐛 Proof of Concept (PoC) *

See tests.

### 🔥 Proof of Fix (PoF) *

See tests.

### 👍 User Acceptance Testing (UAT)

See tests. I also fixed the overarching test suite, which was only running a single test.