### PR TITLE
Add additional functions to Lazy class

### DIFF
--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -89,9 +89,6 @@ class Lazy<T extends AnySchema, TContext = ContextOf<T>>
   isValidSync(value: any, options?: ValidateOptions<TContext>) {
     return this._resolve(value, options).isValidSync(value, options);
   }
-  isType(value: any) {
-    return this._resolve(value).isType(value);
-  }
 }
 
 export default Lazy;

--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -82,6 +82,16 @@ class Lazy<T extends AnySchema, TContext = ContextOf<T>>
   describe() {
     return null as any;
   }
+
+  isValid(value: any, options?: ValidateOptions<TContext>) {
+    return this._resolve(value, options).isValid(value, options);
+  }
+  isValidSync(value: any, options?: ValidateOptions<TContext>) {
+    return this._resolve(value, options).isValidSync(value, options);
+  }
+  isType(value: any) {
+    return this._resolve(value).isType(value);
+  }
 }
 
 export default Lazy;


### PR DESCRIPTION
Add missing functions to Lazy:

    isValid
    isValidSync
    isType

These are all validation functions that have a value parameter, so it makes sense for Lazy to wrap them.