### PR TITLE
Make StringSchema.matches options optional

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -105,7 +105,7 @@ export default class StringSchema<
     });
   }
 
-  matches(regex: RegExp, options: MatchOptions | MatchOptions['message']) {
+  matches(regex: RegExp, options?: MatchOptions | MatchOptions['message']) {
     let excludeEmptyString = false;
     let message;
     let name;


### PR DESCRIPTION
The second parameter to matches() should be optional.