### PR TITLE
Do not initialize spec values with undefined

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -137,8 +137,6 @@ export default abstract class BaseSchema<
       strict: false,
       abortEarly: true,
       recursive: true,
-      label: undefined,
-      meta: undefined,
       nullable: false,
       presence: 'optional',
       ...options?.spec,

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -645,6 +645,19 @@ describe('Mixed Types ', () => {
     }.should.throw(TypeError));
   });
 
+  it('concat should not overwrite label and meta with undefined', function () {
+    const testLabel = "Test Label"
+    const testMeta = {
+      testField: "test field"
+    }
+    let baseSchema = mixed().label(testLabel).meta(testMeta)
+    const otherSchema = mixed()
+
+    baseSchema = baseSchema.concat(otherSchema)
+    expect(baseSchema.spec.label).to.equal(testLabel)
+    expect(baseSchema.spec.meta.testField).to.equal(testMeta.testField)
+  })
+
   it('concat should allow mixed and other type', function () {
     let inst = mixed().default('hi');
 


### PR DESCRIPTION
Otherwise spreading spec values like previously would overwrite the base schema spec values with undefined.
Closes #1160. 