### PR TITLE
Readonly array type for function arguments

### DIFF
--- a/src/Condition.ts
+++ b/src/Condition.ts
@@ -29,7 +29,7 @@ export type ResolveOptions<TContext = any> = {
 class Condition<T extends SchemaLike = SchemaLike> {
   fn: ConditionBuilder<T>;
 
-  constructor(public refs: Reference[], options: ConditionOptions<T>) {
+  constructor(public refs: readonly Reference[], options: ConditionOptions<T>) {
     this.refs = refs;
 
     if (typeof options === 'function') {

--- a/src/ValidationError.ts
+++ b/src/ValidationError.ts
@@ -33,7 +33,7 @@ export default class ValidationError extends Error {
   }
 
   constructor(
-    errorOrErrors: string | ValidationError | ValidationError[],
+    errorOrErrors: string | ValidationError | readonly ValidationError[],
     value?: any,
     field?: string,
     type?: string,

--- a/src/array.ts
+++ b/src/array.ts
@@ -22,7 +22,7 @@ import BaseSchema, {
 } from './schema';
 import Lazy from './Lazy';
 
-export type RejectorFn = (value: any, index: number, array: any[]) => boolean;
+export type RejectorFn = (value: any, index: number, array: readonly any[]) => boolean;
 
 export function create<
   C extends AnyObject = AnyObject,
@@ -251,7 +251,7 @@ export default class ArraySchema<
       ? (v) => !!v
       : (v, i, a) => !rejector(v, i, a);
 
-    return this.transform((values: any[]) =>
+    return this.transform((values: readonly any[]) =>
       values != null ? values.filter(reject) : values,
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function addMethod(schemaType: any, name: string, fn: any) {
 
 type ObjectSchemaOf<T extends AnyObject> = ObjectSchema<
   {
-    [k in keyof T]-?: T[k] extends Array<infer E>
+    [k in keyof T]-?: T[k] extends ReadonlyArray<infer E>
       ? ArraySchema<SchemaOf<E>>
       : T[k] extends AnyObject
       ? // we can't use  ObjectSchema<{ []: SchemaOf<T[k]> }> b/c TS produces a union of two schema
@@ -48,7 +48,7 @@ type ObjectSchemaOf<T extends AnyObject> = ObjectSchema<
   }
 >;
 
-type SchemaOf<T> = T extends Array<infer E>
+type SchemaOf<T> = T extends ReadonlyArray<infer E>
     ? ArraySchema<SchemaOf<E> | Lazy<SchemaOf<E>>>
     : T extends AnyObject
     ? ObjectSchemaOf<T>

--- a/src/object.ts
+++ b/src/object.ts
@@ -331,7 +331,7 @@ export default class ObjectSchema<
 
   shape<TNextShape extends ObjectShape>(
     additions: TNextShape,
-    excludes: [string, string][] = [],
+    excludes: readonly (readonly [string, string])[] = [],
   ): ObjectSchema<
     Assign<TShape, TNextShape>,
     TContext,
@@ -356,7 +356,7 @@ export default class ObjectSchema<
     return next as any;
   }
 
-  pick(keys: string[]) {
+  pick(keys: readonly string[]) {
     const picked: any = {};
     for (const key of keys) {
       if (this.fields[key]) picked[key] = this.fields[key];
@@ -368,7 +368,7 @@ export default class ObjectSchema<
     }) as any;
   }
 
-  omit(keys: string[]): any {
+  omit(keys: readonly string[]): any {
     const next = this.clone() as any;
     const fields = next.fields;
     next.fields = {};
@@ -482,14 +482,14 @@ export interface OptionalObjectSchema<
   ): OptionalObjectSchema<TShape, TContext, Exclude<TIn, null>>;
 
   pick<TKey extends keyof TShape>(
-    keys: TKey[],
+    keys: readonly TKey[],
   ): OptionalObjectSchema<
     Pick<TShape, TKey>,
     TContext,
     TypeOfShape<Pick<TShape, TKey>> | Optionals<TIn>
   >;
   omit<TKey extends keyof TShape>(
-    keys: TKey[],
+    keys: readonly TKey[],
   ): OptionalObjectSchema<
     Omit<TShape, TKey>,
     TContext,
@@ -528,14 +528,14 @@ export interface DefinedObjectSchema<
   ): DefinedObjectSchema<TShape, TContext, Exclude<TIn, null>>;
 
   pick<TKey extends keyof TShape>(
-    keys: TKey[],
+    keys: readonly TKey[],
   ): DefinedObjectSchema<
     Pick<TShape, TKey>,
     TContext,
     TypeOfShape<Pick<TShape, TKey>> | Optionals<TIn>
   >;
   omit<TKey extends keyof TShape>(
-    keys: TKey[],
+    keys: readonly TKey[],
   ): DefinedObjectSchema<
     Omit<TShape, TKey>,
     TContext,
@@ -568,14 +568,14 @@ export interface RequiredObjectSchema<
   ): RequiredObjectSchema<TShape, TContext, Exclude<TIn, null>>;
 
   pick<TKey extends keyof TShape>(
-    keys: TKey[],
+    keys: readonly TKey[],
   ): RequiredObjectSchema<
     Pick<TShape, TKey>,
     TContext,
     TypeOfShape<Pick<TShape, TKey>> | Optionals<TIn>
   >;
   omit<TKey extends keyof TShape>(
-    keys: TKey[],
+    keys: readonly TKey[],
   ): RequiredObjectSchema<
     Omit<TShape, TKey>,
     TContext,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -625,13 +625,13 @@ export default abstract class BaseSchema<
   }
 
   when(options: ConditionOptions<this>): this;
-  when(keys: string | string[], options: ConditionOptions<this>): this;
+  when(keys: string | readonly string[], options: ConditionOptions<this>): this;
   when(
-    keys: string | string[] | ConditionOptions<this>,
+    keys: string | readonly string[] | ConditionOptions<this>,
     options?: ConditionOptions<this>,
   ) {
     if (!Array.isArray(keys) && typeof keys !== 'string') {
-      options = keys;
+      options = keys as ConditionOptions<this>;
       keys = '.';
     }
 
@@ -668,7 +668,7 @@ export default abstract class BaseSchema<
   }
 
   oneOf<U extends TCast>(
-    enums: Array<Maybe<U> | Reference>,
+    enums: ReadonlyArray<Maybe<U> | Reference>,
     message = locale.oneOf,
   ): this {
     var next = this.clone();
@@ -699,7 +699,7 @@ export default abstract class BaseSchema<
   }
 
   notOneOf<U extends TCast>(
-    enums: Array<Maybe<U> | Reference>,
+    enums: ReadonlyArray<Maybe<U> | Reference>,
     message = locale.notOneOf,
   ): this {
     var next = this.clone();

--- a/src/util/sortByKeyOrder.ts
+++ b/src/util/sortByKeyOrder.ts
@@ -1,6 +1,6 @@
 import ValidationError from '../ValidationError';
 
-function findIndex(arr: string[], err: ValidationError) {
+function findIndex(arr: readonly string[], err: ValidationError) {
   let idx = Infinity;
   arr.some((key, ii) => {
     if (err.path?.indexOf(key) !== -1) {
@@ -12,7 +12,7 @@ function findIndex(arr: string[], err: ValidationError) {
   return idx;
 }
 
-export default function sortByKeyOrder(keys: string[]) {
+export default function sortByKeyOrder(keys: readonly string[]) {
   return (a: ValidationError, b: ValidationError) => {
     return findIndex(keys, a) - findIndex(keys, b);
   };

--- a/src/util/toArray.ts
+++ b/src/util/toArray.ts
@@ -1,3 +1,3 @@
-export default function toArray<T>(value?: null | T | T[]) {
+export default function toArray<T>(value?: null | T | readonly T[]) {
   return value == null ? [] : ([] as T[]).concat(value);
 }


### PR DESCRIPTION
### Why

Functions that doesn't require a mutable array must be declared with readonly arrays. Mutable arrays extends readonly arrays, so we can provide a mutable array to a function accepting readonly arrays. But, if we declare a function accepting a mutable array, we cannot provide a readonly array.

Example
```ts
const MY_ENUM_VALS = ['one', 'two', 'three'] as const;

// error: 'readonly ["one", "two", "three"]' is not assignable to the mutable type 'string[]'
yup.string().oneOf(MY_ENUM_VALS);
```

### What & How
Changed function declarations that accepted arrays to accept readonly arrays. I've checked the implementation, we are not mutating arrays received as function arguments.