### PR TITLE
upgraded lodash-es min version from 4.17.11 to 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@babel/runtime": "^7.10.5",
     "@types/lodash": "^4.14.165",
     "lodash": "^4.17.20",
-    "lodash-es": "^4.17.11",
+    "lodash-es": "^4.17.15",
     "nanoclone": "^0.2.1",
     "property-expr": "^2.0.4",
     "toposort": "^2.0.2"


### PR DESCRIPTION
upgraded lodash-es min version from 4.17.11 to 4.17.15 due to security vulnerabilty found by Checkmarx

ran npm run test...all passed