### PR TITLE
doc(validateAt): add sibling casting warning with validateAt

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ but uses the resulting schema as the subject for validation.
 
 > Note! The `value` here is the _root_ value relative to the starting schema, not the value at the nested path.
 
+> Warning! the sibling values of the when validators will not be casted
+
 ```js
 let schema = object({
   foo: array().of(

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ but uses the resulting schema as the subject for validation.
 
 > Note! The `value` here is the _root_ value relative to the starting schema, not the value at the nested path.
 
-> Warning! the sibling values of the when validators will not be casted
+> Warning! the sibling values of the when validators at the nested path will not be casted
 
 ```js
 let schema = object({


### PR DESCRIPTION
the validate and validateAt method differ in the fact that validateAt doesn't cast the siblings dependencies of when at the nested path (see #1116 ) I think this should be warned for in the docs to not surprise the user of yup.