### PR TITLE
Export MixedSchema to fix ts with --declarations

### DIFF
--- a/src/mixed.ts
+++ b/src/mixed.ts
@@ -4,7 +4,7 @@ import { AnyObject, Maybe, Optionals } from './types';
 import type { Defined } from './util/types';
 import BaseSchema from './schema';
 
-declare class MixedSchema<
+export declare class MixedSchema<
   TType = any,
   TContext = AnyObject,
   TOut = TType


### PR DESCRIPTION
Fixes ts error `Exported variable 'Schema' has or is using name 'MixedSchema' from external module "x/node_modules/yup/lib/mixed" but cannot be named.` with --declarations builds.

The MixedSchema class needs to be exported so it can be used in declaration files.