### PR TITLE
Add generic to Reference.create()

### DIFF
--- a/src/Reference.ts
+++ b/src/Reference.ts
@@ -10,8 +10,8 @@ export type ReferenceOptions<TValue = unknown> = {
   map?: (value: unknown) => TValue;
 };
 
-export function create(key: string, options?: ReferenceOptions) {
-  return new Reference(key, options);
+export function create<TValue = unknown>(key: string, options?: ReferenceOptions<TValue>) {
+  return new Reference<TValue>(key, options);
 }
 
 export default class Reference<TValue = unknown> {


### PR DESCRIPTION
The `create()` method in `Reference.ts` was missing the generic, which caused a type error in the following example

```typescript
yup
  .object({
    availableFrom: yup.number(),
    availableTo: yup
      .number()
      .moreThan(yup.ref('availableFrom')),
  });
```

Error:
```
Argument of type 'Reference<unknown>' is not assignable to parameter of type 'number | Reference<number>'.
```

In this PR I add a generic to the `create()` method and type `Reference` and `ReferenceOptions` with it.