### PR TITLE
Array required() and defined() will no longer return any

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -261,6 +261,14 @@ export default class ArraySchema<
     if (this.innerType) base.innerType = this.innerType.describe();
     return base;
   }
+
+  defined(): DefinedArraySchema<T, C, TIn> {
+    return super.defined();
+  }
+
+  required(msg?: MixedLocale['required']): RequiredArraySchema<T, C, TIn> {
+    return super.required(msg);
+  }
 }
 
 create.prototype = ArraySchema.prototype;

--- a/src/array.ts
+++ b/src/array.ts
@@ -262,6 +262,12 @@ export default class ArraySchema<
     return base;
   }
 
+  nullable(isNullable?: true): ArraySchema<T, C, TIn | null>;
+  nullable(isNullable: false): ArraySchema<T, C, Exclude<TIn, null>>;
+  nullable(isNullable = true): ArraySchema<T, C, TIn | null> {
+    return super.nullable(isNullable as any);
+  }
+
   defined(): DefinedArraySchema<T, C, TIn> {
     return super.defined();
   }

--- a/test/types.ts
+++ b/test/types.ts
@@ -265,12 +265,14 @@ SchemaOf: {
     .concat(array(number()).required())
     .validateSync([]);
 
+  // $ExpectType AssertsShape<{ a: RequiredNumberSchema<number | undefined, Record<string, any>>; }>[] | null
   const _definedArray: Array<{ a: number }> | null = array()
     .of(object({ a: number().required() }))
     .nullable()
     .defined()
     .validateSync([]);
-  
+
+  // $ExpectType AssertsShape<{ a: RequiredNumberSchema<number | undefined, Record<string, any>>; }>[]
   const _requiredArray: Array<{ a: number }> = array()
     .of(object({ a: number().required() }))
     .nullable()

--- a/test/types.ts
+++ b/test/types.ts
@@ -264,6 +264,11 @@ SchemaOf: {
   const _c1 = array(number())
     .concat(array(number()).required())
     .validateSync([]);
+
+  const _definedArray: Array<{ a: number }> = array()
+    .of(object({ a: number().required() }))
+    .defined()
+    .validateSync([]);
 }
 
 {

--- a/test/types.ts
+++ b/test/types.ts
@@ -265,9 +265,16 @@ SchemaOf: {
     .concat(array(number()).required())
     .validateSync([]);
 
-  const _definedArray: Array<{ a: number }> = array()
+  const _definedArray: Array<{ a: number }> | null = array()
     .of(object({ a: number().required() }))
+    .nullable()
     .defined()
+    .validateSync([]);
+  
+  const _requiredArray: Array<{ a: number }> = array()
+    .of(object({ a: number().required() }))
+    .nullable()
+    .required()
     .validateSync([]);
 }
 


### PR DESCRIPTION
This merge request is supposed to fix #1253 

We at Opplane <https://opplane.com/> use `yup` on both `frontend` and backend for some of our projects for it's type-safety while keeping it simple.