### PR TITLE
Fix SchemaOf<>'s treatment of Date objects.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,8 @@ type ObjectSchemaOf<T extends AnyObject> = ObjectSchema<
   {
     [k in keyof T]-?: T[k] extends Array<infer E>
       ? ArraySchema<SchemaOf<E> | Lazy<SchemaOf<E>>>
+      : T[k] extends Date
+      ? BaseSchema<Maybe<T[k]>, AnyObject, T[k]>
       : T[k] extends AnyObject
       ? // we can't use  ObjectSchema<{ []: SchemaOf<T[k]> }> b/c TS produces a union of two schema
         ObjectSchemaOf<T[k]> | ObjectSchemaOf<Lazy<T[k]>>
@@ -50,6 +52,8 @@ type ObjectSchemaOf<T extends AnyObject> = ObjectSchema<
 
 type SchemaOf<T> = T extends Array<infer E>
   ? ArraySchema<SchemaOf<E> | Lazy<SchemaOf<E>>>
+  : T extends Date
+  ? BaseSchema<Maybe<T>, AnyObject, T>
   : T extends AnyObject
   ? ObjectSchemaOf<T>
   : BaseSchema<Maybe<T>, AnyObject, T>;

--- a/test/types.ts
+++ b/test/types.ts
@@ -10,6 +10,7 @@ import {
   mixed,
   number,
   ref,
+  date,
   lazy,
   SchemaOf,
 } from '../src';
@@ -200,6 +201,35 @@ SchemaOf: {
     age: number(),
   });
 }
+
+SchemaOfDate: {
+  type Employee = {
+    hire_date: Date;
+    name: string;
+  };
+
+  type EmployeeSchema = SchemaOf<Employee>;
+
+  const _t: EmployeeSchema = object({
+    name: string().defined(),
+    hire_date: date().defined()
+  });
+}
+
+SchemaOfDateArray: {
+  type EmployeeWithPromotions = {
+    promotion_dates: Date[];
+    name: string;
+  };
+
+  type EmployeeWithPromotionsSchema = SchemaOf<EmployeeWithPromotions>;
+
+  const _t: EmployeeWithPromotionsSchema = object({
+    name: string().defined(),
+    promotion_dates: array().of(date().defined())
+  });
+}
+
 
 {
   // const str = string();


### PR DESCRIPTION
Resolve #1243 and #1302.

Add a test for SchemaOf containing Date objects
and an array of date objects.