### PR TITLE
fix(utils): use named functions for default exports

### DIFF
--- a/src/util/isAbsent.ts
+++ b/src/util/isAbsent.ts
@@ -1,1 +1,3 @@
-export default (value: any): value is undefined | null => value == null;
+const isAbsent = (value: any): value is undefined | null => value == null;
+
+export default isAbsent

--- a/src/util/isSchema.ts
+++ b/src/util/isSchema.ts
@@ -1,3 +1,5 @@
 import type { SchemaLike } from '../types';
 
-export default (obj: any): obj is SchemaLike => obj && obj.__isYupSchema__;
+const isSchema = (obj: any): obj is SchemaLike => obj && obj.__isYupSchema__;
+
+export default isSchema


### PR DESCRIPTION
There's ESLint rules that warn on exporting an anonymous arrow function (See #1161) 

While I agree this does not break anything, it seems like a very small fix that does not impact yup and fixes a lot of console spam coming from NextJS (and maybe other projects that check for anonymous functions with fast refresh).