### PR TITLE
allow Lazy as schema when defining array schema

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -177,7 +177,7 @@ export default class ArraySchema<
     return next;
   }
 
-  of<TInner extends AnySchema>(schema: TInner): ArraySchema<TInner> {
+  of<TInner extends AnySchema | Lazy<any, any>>(schema: TInner): ArraySchema<TInner> {
     // FIXME: this should return a new instance of array without the default to be
     let next = this.clone();
 


### PR DESCRIPTION
With the following setup: 

```typescript
const lazySchema = Yup.lazy((value: any) => {
  switch (value.periodicity) {
    case "MONTHLY":
      return Yup.object().shape({
        periodicity: Yup.string().oneOf(["MONTHLY", "WEEKLY"]),
        months: Yup.array().of(Yup.number()),
      });
    case "WEEKLY":
      return Yup.object().shape({
        periodicity: Yup.string().oneOf(["MONTHLY", "WEEKLY"]),
        weeks: Yup.array().of(Yup.number()),
      });
    default:
      return Yup.mixed();
  }
});

const exampleSchema = Yup.object().shape({
  schedules: Yup.array().of(lazySchema),
});

```

I get the following error:

```bash
Argument of type 'Lazy<ObjectSchema<Assign<ObjectShape, { periodicity: StringSchema<string | undefined, Record<string, any>, string | undefined>; months: ArraySchema<NumberSchema<number | undefined, Record<...>, number | undefined>, AnyObject, (number | undefined)[] | undefined, (number | undefined)[] | undefined>; }>, Record<...>, T...' is not assignable to parameter of type 'AnySchema<any, any, any>'.
  Type 'Lazy<ObjectSchema<Assign<ObjectShape, { periodicity: StringSchema<string | undefined, Record<string, any>, string | undefined>; months: ArraySchema<NumberSchema<number | undefined, Record<...>, number | undefined>, AnyObject, (number | undefined)[] | undefined, (number | undefined)[] | undefined>; }>, Record<...>, T...' is missing the following properties from type 'BaseSchema<any, any, any>': deps, tests, transforms, conditions, and 35 more.  TS2345
```

I'm not entirely sure if this is the correct way, but I fixed it by adding `Lazy` to the allowed schema types. 