### PR TITLE
Allows custom types to be passed to avoid cast to ObjectSchema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ type ObjectSchemaOf<T extends AnyObject, CustomTypes = never> = ObjectSchema<
       ? BaseSchema<Maybe<T[k]>, AnyObject, T[k]>
       : T[k] extends AnyObject
       ? // we can't use  ObjectSchema<{ []: SchemaOf<T[k]> }> b/c TS produces a union of two schema
-        ObjectSchemaOf<T[k], CustomTypes> | ObjectSchemaOf<Lazy<T[k]>, CustomTypes>
+        ObjectSchemaOf<T[k], CustomTypes> | Lazy<ObjectSchemaOf<T[k], CustomTypes>>
       : BaseSchema<Maybe<T[k]>, AnyObject, T[k]>;
   }
 >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,25 +37,25 @@ function addMethod(schemaType: any, name: string, fn: any) {
   schemaType.prototype[name] = fn;
 }
 
-type ObjectSchemaOf<T extends AnyObject> = ObjectSchema<
+type ObjectSchemaOf<T extends AnyObject, CustomTypes = never> = ObjectSchema<
   {
     [k in keyof T]-?: T[k] extends Array<infer E>
-      ? ArraySchema<SchemaOf<E> | Lazy<SchemaOf<E>>>
-      : T[k] extends Date
+      ? ArraySchema<SchemaOf<E, CustomTypes> | Lazy<SchemaOf<E, CustomTypes>>>
+      : T[k] extends Date | CustomTypes
       ? BaseSchema<Maybe<T[k]>, AnyObject, T[k]>
       : T[k] extends AnyObject
       ? // we can't use  ObjectSchema<{ []: SchemaOf<T[k]> }> b/c TS produces a union of two schema
-        ObjectSchemaOf<T[k]> | ObjectSchemaOf<Lazy<T[k]>>
+        ObjectSchemaOf<T[k], CustomTypes> | ObjectSchemaOf<Lazy<T[k]>, CustomTypes>
       : BaseSchema<Maybe<T[k]>, AnyObject, T[k]>;
   }
 >;
 
-type SchemaOf<T> = T extends Array<infer E>
-  ? ArraySchema<SchemaOf<E> | Lazy<SchemaOf<E>>>
-  : T extends Date
+type SchemaOf<T, CustomTypes = never> = T extends Array<infer E>
+  ? ArraySchema<SchemaOf<E, CustomTypes> | Lazy<SchemaOf<E, CustomTypes>>>
+  : T extends Date | CustomTypes
   ? BaseSchema<Maybe<T>, AnyObject, T>
   : T extends AnyObject
-  ? ObjectSchemaOf<T>
+  ? ObjectSchemaOf<T, CustomTypes>
   : BaseSchema<Maybe<T>, AnyObject, T>;
 
 export type AnyObjectSchema = ObjectSchema<any, any, any, any>;

--- a/test/types.ts
+++ b/test/types.ts
@@ -230,6 +230,36 @@ SchemaOfDateArray: {
   });
 }
 
+SchemaOfFile: {
+  type Document = {
+    file: File;
+    date_uploaded: Date;
+    notes: string;
+  };
+
+  type FileSchema = SchemaOf<Document, File>;
+
+  const _t: FileSchema = object({
+    file: mixed<File>().defined(),
+    date_uploaded: date().defined(),
+    notes: string().defined(),
+  });
+}
+
+SchemaOfFileArray: {
+  type DocumentWithFullHistory = {
+    history: File[];
+    name: string;
+  };
+
+  type DocumentWithFullHistorySchema = SchemaOf<DocumentWithFullHistory, File>;
+
+  const _t: DocumentWithFullHistorySchema = object({
+    name: string().defined(),
+    history: array().of(mixed<File>().defined())
+  });
+}
+
 
 {
   // const str = string();


### PR DESCRIPTION
Similar to  #1305, this allows the user to implement their own types for classes and not have fields forced to be of type ObjectSchema. This is very helpful when wanting to extend yup for ` js-joda LocalTime` for example.

This is backwards compatible as the new generic type `CustomTypes` is not mandatory and is defaulted to never. 