### PR TITLE
Fix typescript.md

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -61,7 +61,7 @@ import type { TypeOf } from 'yup';
 
 interface PersonInput extends TypeOf<typeof personSchema> {}
 
-const validated: PersonInput = personSchema.cast(json);
+const casted: PersonInput = personSchema.cast(json);
 ```
 
 You can also go the other direction, specifying an interface and ensuring that a schema would match it:


### PR DESCRIPTION
![スクリーンショット 2021-11-22 21 35 01](https://user-images.githubusercontent.com/7888582/142862705-b8aa2ef3-9616-4adf-bf4c-610d3b36877d.png)

In this sample, the return value name of cast is `validated`.
But I think, cast don't validate, so it might create some confusion.
(Sorry, if my understanding is wrong.)

So I change name to `casted`.
Please check my change.