### PR TITLE
Add originalValue to TestContext type

### DIFF
--- a/src/util/createValidation.ts
+++ b/src/util/createValidation.ts
@@ -21,6 +21,7 @@ export type CreateErrorOptions = {
 export type TestContext<TContext = {}> = {
   path: string;
   options: ValidateOptions<TContext>;
+  originalValue: any;
   parent: any;
   schema: any; // TODO: Schema<any>;
   resolve: <T>(value: T | Reference<T>) => T;


### PR DESCRIPTION
`originalValue` is listed as a valid property on `testContext` [per the docs](https://github.com/jquense/yup#mixedtestname-string-message-string--function-test-function-schema), and also exists on [the community types for yup](https://github.com/abnersajr/DefinitelyTyped/blob/a186d99d0c3a92424691a82130374a1b9145c7cd/types/yup/index.d.ts#L446), but it is missing in the official types.

Fixes #1335