### PR TITLE
feat: concat() is shallow and does not merge

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,22 +1,8 @@
 ## TypeScript Support
 
-`yup` comes with robust typescript support! However, because of how dynamic `yup` is
-not everything can be statically typed safely, but for most cases it's "Good Enough".
-
-Note that `yup` schema actually produce _two_ different types: the result of casting an input, and the value after validation.
-Why are these types different? Because a schema can produce a value via casting that
-would not pass validation!
-
-```js
-const schema = string().nullable().required();
-
-schema.cast(null); // -> null
-schema.validateSync(null); // ValidationError this is required!
-```
-
-By itself this seems weird, but has it's uses when handling user input. To get a
-TypeScript type that matches all possible `cast()` values, use `yup.TypeOf<typeof schema>`.
-To produce a type that matches a valid object for the schema use `yup.Asserts<typeof schema>>`
+`yup` comes with robust typescript support, producing values and types from schema that
+provide compile time type safety as well as runtime parsing and validation. Schema refine
+their output as
 
 ```ts
 import * as yup from 'yup';
@@ -46,12 +32,11 @@ const personSchema = yup.object({
 You can derive a type for the final validated object as follows:
 
 ```ts
-import type { Asserts } from 'yup';
+import type { InferType } from 'yup';
 
-// you can also use a type alias by this displays better in tooling
-interface Person extends Asserts<typeof personSchema> {}
+type Person = InferType<typeof personSchema>;
 
-const validated: Person = personSchema.validateSync(parsed);
+const validated: Person = await personSchema.validate(value);
 ```
 
 If you want the type produced by casting:

--- a/src/mixed.ts
+++ b/src/mixed.ts
@@ -1,5 +1,6 @@
-import { AnyObject, Maybe, Message, Optionals } from './types';
+import { AnyObject, Maybe, Message } from './types';
 import type {
+  Concat,
   Defined,
   Flags,
   SetFlag,
@@ -21,15 +22,10 @@ export declare class MixedSchema<
 
   concat<IT, IC, ID, IF extends Flags>(
     schema: MixedSchema<IT, IC, ID, IF>,
-  ): MixedSchema<NonNullable<TType> | IT, TContext & IC, ID, TFlags | IF>;
+  ): MixedSchema<Concat<TType, IT>, TContext & IC, ID, TFlags | IF>;
   concat<IT, IC, ID, IF extends Flags>(
     schema: BaseSchema<IT, IC, ID, IF>,
-  ): MixedSchema<
-    NonNullable<TType> | Optionals<IT>,
-    TContext & IC,
-    ID,
-    TFlags | IF
-  >;
+  ): MixedSchema<Concat<TType, IT>, TContext & IC, ID, TFlags | IF>;
   concat(schema: this): this;
 
   defined(

--- a/src/object.ts
+++ b/src/object.ts
@@ -3,14 +3,12 @@ import { getter, normalizePath, join } from 'property-expr';
 import { camelCase, snakeCase } from 'tiny-case';
 
 import {
-  Concat,
   Flags,
   ISchema,
   SetFlag,
   ToggleDefault,
   UnsetFlag,
 } from './util/types';
-
 import { object as locale } from './locale';
 import sortFields from './util/sortFields';
 import sortByKeyOrder from './util/sortByKeyOrder';
@@ -23,6 +21,7 @@ import BaseSchema, { SchemaObjectDescription, SchemaSpec } from './schema';
 import { ResolveOptions } from './Condition';
 import type {
   AnyObject,
+  ConcatObjectTypes,
   DefaultFromShape,
   MakePartial,
   MergeObjectTypes,
@@ -74,7 +73,7 @@ export default interface ObjectSchema<
   // important that this is `any` so that using `ObjectSchema<MyType>`'s default
   // will match object schema regardless of defaults
   TDefault = any,
-  TFlags extends Flags = 'd',
+  TFlags extends Flags = '',
 > extends BaseSchema<MakeKeysOptional<TIn>, TContext, TDefault, TFlags> {
   default<D extends Maybe<AnyObject>>(
     def: Thunk<D>,
@@ -105,14 +104,14 @@ export default class ObjectSchema<
   TIn extends Maybe<AnyObject>,
   TContext = AnyObject,
   TDefault = any,
-  TFlags extends Flags = 'd',
+  TFlags extends Flags = '',
 > extends BaseSchema<MakeKeysOptional<TIn>, TContext, TDefault, TFlags> {
   fields: Shape<NonNullable<TIn>, TContext> = Object.create(null);
 
   declare spec: ObjectSchemaSpec;
 
   private _sortErrors = defaultSort;
-  private _nodes: string[] = []; //readonly (keyof TIn & string)[]
+  private _nodes: string[] = [];
 
   private _excludedEdges: readonly [nodeA: string, nodeB: string][] = [];
 
@@ -312,7 +311,12 @@ export default class ObjectSchema<
 
   concat<IIn, IC, ID, IF extends Flags>(
     schema: ObjectSchema<IIn, IC, ID, IF>,
-  ): ObjectSchema<Concat<TIn, IIn>, TContext & IC, TDefault & ID, TFlags | IF>;
+  ): ObjectSchema<
+    ConcatObjectTypes<TIn, IIn>,
+    TContext & IC,
+    Extract<IF, 'd'> extends never ? _<ConcatObjectTypes<TDefault, ID>> : ID,
+    TFlags | IF
+  >;
   concat(schema: this): this;
   concat(schema: any): any {
     let next = super.concat(schema) as any;
@@ -320,14 +324,7 @@ export default class ObjectSchema<
     let nextFields = next.fields;
     for (let [field, schemaOrRef] of Object.entries(this.fields)) {
       const target = nextFields[field];
-      if (target === undefined) {
-        nextFields[field] = schemaOrRef;
-      } else if (
-        target instanceof BaseSchema &&
-        schemaOrRef instanceof BaseSchema
-      ) {
-        nextFields[field] = schemaOrRef.concat(target);
-      }
+      nextFields[field] = target === undefined ? schemaOrRef : target;
     }
 
     return next.withMutation((s: any) =>

--- a/src/object.ts
+++ b/src/object.ts
@@ -3,6 +3,7 @@ import { getter, normalizePath, join } from 'property-expr';
 import { camelCase, snakeCase } from 'tiny-case';
 
 import {
+  Concat,
   Flags,
   ISchema,
   SetFlag,
@@ -311,12 +312,7 @@ export default class ObjectSchema<
 
   concat<IIn, IC, ID, IF extends Flags>(
     schema: ObjectSchema<IIn, IC, ID, IF>,
-  ): ObjectSchema<
-    NonNullable<TIn> | IIn,
-    TContext & IC,
-    TDefault & ID,
-    TFlags | IF
-  >;
+  ): ObjectSchema<Concat<TIn, IIn>, TContext & IC, TDefault & ID, TFlags | IF>;
   concat(schema: this): this;
   concat(schema: any): any {
     let next = super.concat(schema) as any;

--- a/src/util/objectTypes.ts
+++ b/src/util/objectTypes.ts
@@ -20,6 +20,15 @@ export type MergeObjectTypes<T extends Maybe<AnyObject>, U extends AnyObject> =
   | ({ [P in keyof T]: P extends keyof U ? U[P] : T[P] } & U)
   | Optionals<T>;
 
+export type ConcatObjectTypes<
+  T extends Maybe<AnyObject>,
+  U extends Maybe<AnyObject>,
+> =
+  | ({
+      [P in keyof T]: P extends keyof NonNullable<U> ? NonNullable<U>[P] : T[P];
+    } & U)
+  | Optionals<U>;
+
 export type PartialDeep<T> = T extends
   | string
   | number

--- a/test/types/types.ts
+++ b/test/types/types.ts
@@ -633,8 +633,17 @@ Object: {
       name: string(),
     }).nullable();
 
-    // $ExpectType "foo" | null
+    // $ExpectType { name?: string | undefined; other: string; field: number; } | null
     obj1.concat(obj2).cast('');
+
+    // $ExpectType { name?: string | undefined; other: string; field: number; }
+    obj1.nullable().concat(obj2.nonNullable()).cast('');
+
+    // $ExpectType { field: 1; other: ""; name: undefined; }
+    obj1.nullable().concat(obj2.nonNullable()).getDefault();
+
+    // $ExpectType null
+    obj1.concat(obj2.default(null)).getDefault();
   }
 
   SchemaOfDate: {

--- a/test/types/types.ts
+++ b/test/types/types.ts
@@ -622,6 +622,21 @@ Object: {
   // $ExpectType string
   merge.cast({}).other;
 
+  Concat: {
+    const obj1 = object({
+      field: string().required(),
+      other: string().default(''),
+    });
+
+    const obj2 = object({
+      field: number().default(1),
+      name: string(),
+    }).nullable();
+
+    // $ExpectType "foo" | null
+    obj1.concat(obj2).cast('');
+  }
+
   SchemaOfDate: {
     type Employee = {
       hire_date: Date;


### PR DESCRIPTION
BREAKING CHANGE: concat works shallowly now. Previously concat functioned like a deep merge for object, which produced confusing behavior with incompatible concat'ed schema. Now `concat` for objects works similar to how it works for other types, the provided schema is applied on top of the existing schema, producing a new schema that is the same as calling each builder method in order