### PR TITLE
🐛 Fix string.url() for localhost and ftp URL

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -153,10 +153,21 @@ export default class StringSchema<
       name: name || 'matches',
       message: message || locale.matches,
       params: { regex },
-      test: (value: Maybe<string>) =>
-        isAbsent(value) ||
-        (value === '' && excludeEmptyString) ||
-        value.search(regex) !== -1,
+      test: (value: Maybe<string>) => {
+        const regexTest =
+          isAbsent(value) ||
+          (value === '' && excludeEmptyString) ||
+          value.search(regex) !== -1;
+
+        if (regexTest) return regexTest;
+
+        try {
+          new URL(value);
+          return true;
+        } catch (e) {
+          return false;
+        }
+      },
     });
   }
 

--- a/test/string.ts
+++ b/test/string.ts
@@ -193,7 +193,15 @@ describe('String types', () => {
 
     return Promise.all([
       expect(v.isValid('//www.github.com/')).resolves.toBe(true),
+      expect(v.isValid('http://www.github.com/')).resolves.toBe(true),
       expect(v.isValid('https://www.github.com/')).resolves.toBe(true),
+      expect(v.isValid('http://localhost:3000')).resolves.toBe(true),
+      expect(v.isValid('http://localhost:3000/')).resolves.toBe(true),
+      expect(v.isValid('http://localhost')).resolves.toBe(true),
+      expect(v.isValid('http://localhost/')).resolves.toBe(true),
+      expect(v.isValid('ftp://localhost:21')).resolves.toBe(true),
+      expect(v.isValid('ftp://localhost:3333/')).resolves.toBe(true),
+      expect(v.isValid('ftp://localhost')).resolves.toBe(true),
       expect(v.isValid('this is not a url')).resolves.toBe(false),
     ]);
   });


### PR DESCRIPTION
I had problems with `string.url()` validating `localhost` URLs, so that's the motivation of this PR.

I tried also to send a PR for the last stable release in npm `v0.32.11` (and that I'm using in a project), but this version's tests suite is broken. So, I'm sending the PR for the last version in the master branch.

Fix #1271 
Fix #800 