### PR TITLE
fix: allow empty message for string.matches()

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -151,10 +151,10 @@ export default class StringSchema<
 
   matches(regex: RegExp, options?: MatchOptions | MatchOptions['message']) {
     let excludeEmptyString = false;
-    let message;
-    let name;
+    let message = locale.matches;
+    let name = 'matches';
 
-    if (options) {
+    if (options !== undefined) {
       if (typeof options === 'object') {
         ({
           excludeEmptyString = false,
@@ -167,8 +167,8 @@ export default class StringSchema<
     }
 
     return this.test({
-      name: name || 'matches',
-      message: message || locale.matches,
+      name,
+      message,
       params: { regex },
       skipAbsent: true,
       test: (value: Maybe<string>) =>


### PR DESCRIPTION
I wanted to return an empty error message on my fields. It worked with `string().required('')`, `string.min(10, '')` but not `string.matches(regex, '')` as it displayed the default error message.

This PR allows to have empty error messages for `string().matches(regex, '')` or `string().matches({message: ''})` (and subsequently, for `string().email('')`, `string().url('')` and `string().uuid('')`).

I also moved the default value of `message` and `name` in `matches()`, it doesn't cause a regression.