### PR TITLE
Offering relaxed uuid matching to support draft UUID proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,9 +1283,10 @@ Validates the value as an email address via a regex.
 
 Validates the value as a valid URL via a regex.
 
-#### `string.uuid(message?: string | function): Schema`
+#### `string.uuid(message?: string | function, strict: bool): Schema`
 
-Validates the value as a valid UUID via a regex.
+Validates the value as a valid UUID via a regex.  
+`strict=true` allows only the most common uuid versions (preferably uuid v3, v4), while `strict=false` allows anything that vaguely looks like an uuid. 
 
 #### `string.ensure(): Schema`
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ import {
     - [`string.matches(regex: Regex, options: { message: string, excludeEmptyString: bool }): Schema`](#stringmatchesregex-regex-options--message-string-excludeemptystring-bool--schema)
     - [`string.email(message?: string | function): Schema`](#stringemailmessage-string--function-schema)
     - [`string.url(message?: string | function): Schema`](#stringurlmessage-string--function-schema)
-    - [`string.uuid(message?: string | function): Schema`](#stringuuidmessage-string--function-strict-bool-schema)
+    - [`string.uuid(message?: string | function, strict: boolean=true): Schema`](#stringuuidmessage-string--function-strict-bool--false-schema)
     - [`string.ensure(): Schema`](#stringensure-schema)
     - [`string.trim(message?: string | function): Schema`](#stringtrimmessage-string--function-schema)
     - [`string.lowercase(message?: string | function): Schema`](#stringlowercasemessage-string--function-schema)
@@ -1283,7 +1283,7 @@ Validates the value as an email address via a regex.
 
 Validates the value as a valid URL via a regex.
 
-#### `string.uuid(message?: string | function, strict: bool): Schema`
+#### `string.uuid(message?: string | function, strict: boolean=true): Schema`
 
 Validates the value as a valid UUID via a regex.  
 `strict=true` allows only the most common uuid versions (preferably uuid v3, v4), while `strict=false` allows anything that vaguely looks like an uuid. 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ import {
     - [`string.matches(regex: Regex, options: { message: string, excludeEmptyString: bool }): Schema`](#stringmatchesregex-regex-options--message-string-excludeemptystring-bool--schema)
     - [`string.email(message?: string | function): Schema`](#stringemailmessage-string--function-schema)
     - [`string.url(message?: string | function): Schema`](#stringurlmessage-string--function-schema)
-    - [`string.uuid(message?: string | function, strict: boolean=true): Schema`](#stringuuidmessage-string--function-strict-bool--false-schema)
+    - [`string.uuid(message?: string | function, strict: boolean=true): Schema`](#stringuuidmessage-string--function-strict-booleantrue-schema)
     - [`string.ensure(): Schema`](#stringensure-schema)
     - [`string.trim(message?: string | function): Schema`](#stringtrimmessage-string--function-schema)
     - [`string.lowercase(message?: string | function): Schema`](#stringlowercasemessage-string--function-schema)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ import {
     - [`string.matches(regex: Regex, options: { message: string, excludeEmptyString: bool }): Schema`](#stringmatchesregex-regex-options--message-string-excludeemptystring-bool--schema)
     - [`string.email(message?: string | function): Schema`](#stringemailmessage-string--function-schema)
     - [`string.url(message?: string | function): Schema`](#stringurlmessage-string--function-schema)
-    - [`string.uuid(message?: string | function): Schema`](#stringuuidmessage-string--function-schema)
+    - [`string.uuid(message?: string | function): Schema`](#stringuuidmessage-string--function-strict-bool-schema)
     - [`string.ensure(): Schema`](#stringensure-schema)
     - [`string.trim(message?: string | function): Schema`](#stringtrimmessage-string--function-schema)
     - [`string.lowercase(message?: string | function): Schema`](#stringlowercasemessage-string--function-schema)

--- a/src/string.ts
+++ b/src/string.ts
@@ -28,6 +28,9 @@ let rUrl =
 let rUUID =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 
+let rUUIDNotStrict =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 let isTrimmed = (value: Maybe<string>) =>
   isAbsent(value) || value === value.trim();
 
@@ -192,8 +195,8 @@ export default class StringSchema<
     });
   }
 
-  uuid(message = locale.uuid) {
-    return this.matches(rUUID, {
+  uuid(message = locale.uuid, strict=true) {
+    return this.matches(strict ? rUUID : rUUIDNotStrict, {
       name: 'uuid',
       message,
       excludeEmptyString: false,

--- a/test/string.ts
+++ b/test/string.ts
@@ -211,9 +211,45 @@ describe('String types', () => {
       expect(v.isValid('42c4a747-3e3e-zzzz-af30-469cfb9c1913')).resolves.toBe(
         false,
       ),
+      expect(v.isValid('1ec131c5-4069-65c0-9eee-055c04bb4f08')).resolves.toBe( // uuid v6
+        false, // in strict mode (normal mode), it should reject the uuid v6.
+      ),
       expect(v.isValid('this is not a uuid')).resolves.toBe(false),
       expect(v.isValid('')).resolves.toBe(false),
     ]);
+  });
+
+  it('should check UUID (not strict) correctly', function() {
+    let vNotStrict = string().uuid(undefined, false);
+
+    return Promise.all([
+      expect(vNotStrict.isValid('1ec131c5-4069-65c0-9eee-055c04bb4f08')).resolves.toBe( // uuid v6
+        true, // in not-strict mode, it should accept any uuid-similar value
+      ),
+      expect(vNotStrict.isValid('1eb0d1d0-126a-6495-9a93-171634969e27')).resolves.toBe( // uuid v6
+        true
+      ),
+      expect(vNotStrict.isValid('1eb0d1d5-c3fa-6b2e-8d7a-ef182baf6b94')).resolves.toBe( // uuid v6
+        true
+      ),
+      expect(vNotStrict.isValid('03bf0706-b7e9-33b8-aee5-c6142a816478')).resolves.toBe( // uuid v3
+        true,
+      ),
+      expect(vNotStrict.isValid('3c69679f-774b-4fb1-80c1-7b29c6e7d0a0')).resolves.toBe( // uuid v1
+        true,
+      ),
+      expect(vNotStrict.isValid('0c40428c-d88d-4ff0-a5dc-a6755cb4f4d1')).resolves.toBe(
+        true,
+      ),
+      expect(vNotStrict.isValid('42c4a747-3e3e-42be-af30-469cfb9c1913')).resolves.toBe(
+        true,
+      ),
+      expect(vNotStrict.isValid('42c4a747-3e3e-zzzz-af30-469cfb9c1913')).resolves.toBe(
+        false,
+      ),
+      expect(vNotStrict.isValid('this is not a uuid')).resolves.toBe(false),
+      expect(vNotStrict.isValid('')).resolves.toBe(false),
+    ])
   });
 
   xit('should check allowed values at the end', () => {


### PR DESCRIPTION
Rectifying the suggestions in #1610.

Added an addition regex to support relaxed uuid matching, which would allow anything that vaguely looks like an uuid. 
Also, updated the README.md.