### PR TITLE
Fix typo: coarce -> coerce

### DIFF
--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -41,7 +41,7 @@ export default class BooleanSchema<
 
     this.withMutation(() => {
       this.transform((value, _raw, ctx) => {
-        if (ctx.spec.coarce && !ctx.isType(value)) {
+        if (ctx.spec.coerce && !ctx.isType(value)) {
           if (/^(true|1)$/i.test(String(value))) return true;
           if (/^(false|0)$/i.test(String(value))) return false;
         }

--- a/src/date.ts
+++ b/src/date.ts
@@ -47,7 +47,7 @@ export default class DateSchema<
 
     this.withMutation(() => {
       this.transform((value, _raw, ctx) => {
-        if (!ctx.spec.coarce || ctx.isType(value)) return value;
+        if (!ctx.spec.coerce || ctx.isType(value)) return value;
 
         value = isoParse(value);
 

--- a/src/number.ts
+++ b/src/number.ts
@@ -44,7 +44,7 @@ export default class NumberSchema<
 
     this.withMutation(() => {
       this.transform((value, _raw, ctx) => {
-        if (!ctx.spec.coarce) return value;
+        if (!ctx.spec.coerce) return value;
 
         let parsed = value;
         if (typeof parsed === 'string') {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -35,7 +35,7 @@ import toArray from './util/toArray';
 import cloneDeep from './util/cloneDeep';
 
 export type SchemaSpec<TDefault> = {
-  coarce: boolean;
+  coerce: boolean;
   nullable: boolean;
   optional: boolean;
   default?: TDefault | (() => TDefault);
@@ -170,7 +170,7 @@ export default abstract class Schema<
       recursive: true,
       nullable: false,
       optional: true,
-      coarce: true,
+      coerce: true,
       ...options?.spec,
     };
 

--- a/src/string.ts
+++ b/src/string.ts
@@ -67,7 +67,7 @@ export default class StringSchema<
 
     this.withMutation(() => {
       this.transform((value, _raw, ctx) => {
-        if (!ctx.spec.coarce || ctx.isType(value)) return value;
+        if (!ctx.spec.coerce || ctx.isType(value)) return value;
 
         // don't ever convert arrays
         if (Array.isArray(value)) return value;


### PR DESCRIPTION
Following up #1654 with the remaining instances of `coarce` 