### PR TITLE
Standard RFC compliance email validation

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -18,7 +18,7 @@ import Schema from './schema';
 
 let rEmail =
   // eslint-disable-next-line
-  /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
+  /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/i;
 
 let rUrl =
   // eslint-disable-next-line

--- a/test/string.ts
+++ b/test/string.ts
@@ -131,6 +131,38 @@ describe('String types', () => {
     return expect(v.isValid('')).resolves.toBe(true);
   });
 
+  it('EMAIL should NOT include special characters', () => {
+    let v = string().email();
+
+    return expect(v.isValid('“example”@email.com')).resolves.toBe(false);
+  });
+
+  it('EMAIL should NOT include qoutation characters', () => {
+    let v = string().email();
+
+    expect(v.isValid('“example”@email.com')).resolves.toBe(false);
+    expect(v.isValid('“obviously”not”correct@email.com')).resolves.toBe(false);
+  });
+
+  it('EMAIL should NOT include consecutive periods `....` characters', () => {
+    let v = string().email();
+
+    expect(v.isValid('example…example@email.com')).resolves.toBe(false);
+    expect(v.isValid('CAT…123@email.com')).resolves.toBe(false);
+  });
+
+  it('EMAIL should NOT include other languages characters', () => {
+    let v = string().email();
+
+    return expect(v.isValid('おえあいう@example.com')).resolves.toBe(false);
+  });
+
+  it('EMAIL should validate DNS resolve numbers email', () => {
+    let v = string().email();
+
+    return expect(v.isValid('example@111.222.333.44444')).resolves.toBe(true);
+  });
+
   it('should check MIN correctly', function () {
     let v = string().min(5);
     let obj = object({

--- a/test/string.ts
+++ b/test/string.ts
@@ -131,12 +131,6 @@ describe('String types', () => {
     return expect(v.isValid('')).resolves.toBe(true);
   });
 
-  it('EMAIL should NOT include special characters', () => {
-    let v = string().email();
-
-    return expect(v.isValid('“example”@email.com')).resolves.toBe(false);
-  });
-
   it('EMAIL should NOT include qoutation characters', () => {
     let v = string().email();
 


### PR DESCRIPTION
Hello, I hope you are doing well. 

The current regex for validating emails is not validating correctly for the following cases. 

- “example”@email.com
- “obviously”not”correct@email.com
- example…example@email.com
- CAT…123@email.com
- おえあいう@example.com
- example@111.222.333.44444

**Problem**
Current regex doesn't validate these cases. 

**Solution:** 
I have added a new regex for email validation that is supported by RFC. The supportive links are given below. 

**References:** 
- https://datatracker.ietf.org/doc/html/rfc3696
- https://datatracker.ietf.org/doc/html/rfc5321
- https://datatracker.ietf.org/doc/html/rfc5322


