### PR TITLE
update type TypeFromShape

### DIFF
--- a/src/util/objectTypes.ts
+++ b/src/util/objectTypes.ts
@@ -7,7 +7,7 @@ export type ObjectShape = { [k: string]: ISchema<any> | Reference };
 export type AnyObject = { [k: string]: any };
 
 export type TypeFromShape<S extends ObjectShape, C> = {
-  [K in keyof S]: S[K] extends ISchema<any, C> ? S[K]['__outputType'] : unknown;
+  [K in keyof S]: S[K] extends ISchema<infer T, C> ? T : unknown;
 };
 
 export type DefaultFromShape<Shape extends ObjectShape> = {


### PR DESCRIPTION
Infer outputType using Typescript `infer` feature as build is failing locally.

```ts
// src/types.ts
export interface ISchema<T, C = AnyObject, F extends Flags = any, D = any> {
  __flags: F;
  __context: C;
  __outputType: T;
```