### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@ Alternatively you can provide a function that returns a schema, called with an a
 ```js
 let schema = yup.object({
   isBig: yup.boolean(),
-  count: yup.number().when('isBig', ([isBig], schema) => {
+  count: yup.number().when('isBig', (isBig, schema) => {
     return isBig ? schema.min(5) : schema.min(0);
   }),
 });


### PR DESCRIPTION
The current docs recommend destructuring as an array here. However, this throws an error, since it's returning the value when you pass `'isBig'` as a string directly.