### PR TITLE
feat: add cast nullability migration path.

### DIFF
--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -8,6 +8,7 @@ import type {
 import type { ResolveOptions } from './Condition';
 
 import type {
+  CastOptionalityOptions,
   CastOptions,
   SchemaFieldDescription,
   SchemaLazyDescription,
@@ -88,8 +89,16 @@ class Lazy<T, TContext = AnyObject, TFlags extends Flags = any>
     return this._resolve(options.value, options);
   }
 
-  cast(value: any, options?: CastOptions<TContext>): T {
-    return this._resolve(value, options).cast(value, options);
+  cast(value: any, options?: CastOptions<TContext>): T;
+  cast(
+    value: any,
+    options?: CastOptionalityOptions<TContext>,
+  ): T | null | undefined;
+  cast(
+    value: any,
+    options?: CastOptions<TContext> | CastOptionalityOptions<TContext>,
+  ): any {
+    return this._resolve(value, options).cast(value, options as any);
   }
 
   asNestedTest(options: NestedTestConfig) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { ResolveOptions } from './Condition';
 import type {
   AnySchema,
+  CastOptionalityOptions,
   CastOptions,
   SchemaFieldDescription,
   SchemaSpec,
@@ -18,6 +19,8 @@ export interface ISchema<T, C = AnyObject, F extends Flags = any, D = any> {
   __default: D;
 
   cast(value: any, options?: CastOptions<C>): T;
+  cast(value: any, options: CastOptionalityOptions<C>): T | null | undefined;
+
   validate(value: any, options?: ValidateOptions<C>): Promise<T>;
 
   asNestedTest(config: NestedTestConfig): Test;

--- a/test/mixed.ts
+++ b/test/mixed.ts
@@ -87,6 +87,16 @@ describe('Mixed Types ', () => {
     );
   });
 
+  it('should allow missing values with the "ignore-optionality" option', () => {
+    expect(
+      string().required().cast(null, { assert: 'ignore-optionality' }),
+    ).toBe(null);
+
+    expect(
+      string().required().cast(undefined, { assert: 'ignore-optionality' }),
+    ).toBe(undefined);
+  });
+
   it('should warn about null types', async () => {
     await expect(string().strict().validate(null)).rejects.toThrowError(
       /this cannot be null/,

--- a/test/types/types.ts
+++ b/test/types/types.ts
@@ -100,6 +100,12 @@ Mixed: {
     type: 'string',
     check: (value): value is string => typeof value === 'string',
   });
+
+  // $ExpectType string
+  mixed<string>().defined().cast('', { assert: true });
+
+  // $ExpectType string | null | undefined
+  mixed<string>().defined().cast('', { assert: 'ignore-optionality' });
 }
 
 Strings: {


### PR DESCRIPTION
Adds a `cast` option to not throw on optionality mismatches after casting. This is being added to support migration from pre-v1 where cases like `string().nullable().required()` are supported. This case is generally used to handle parsing server side "default" values to feed into a form. Initial values may be null or missing but require filling in by a user before submitting the value back to server. 

Going forward the approved way to handle these cases is with multiple schema using conditional when's to set `nullable` or using `schema.deepPartial()` to create an optional version of itself.