### PR TITLE
Fix check instanceof of ValidationError

### DIFF
--- a/src/ValidationError.ts
+++ b/src/ValidationError.ts
@@ -39,6 +39,7 @@ export default class ValidationError extends Error {
     type?: string,
   ) {
     super();
+    Object.setPrototypeOf(this, ValidationError.prototype);
 
     this.name = 'ValidationError';
     this.value = value;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "allowJs": true,
     "rootDir": "src",
-    "strictFunctionTypes": true
+    "strictFunctionTypes": true,
+    "lib": [
+      "dom",
+      "ES2015",
+      "ES2019"
+    ]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Hello :wave: 

I'm submitting this PR to fix an issue I'm facing on a project. 

With at least typescript 2.6.2, I'm facing the following issue described [in the FAQ](https://github.com/Microsoft/TypeScript/wiki/FAQ#why-doesnt-extending-built-ins-like-error-array-and-map-work). 

My fix implements the suggested way. However, I'm not completely satisfied by it, and I would understand that you would not be either. The fix comes with a potential performance hit if used heavily, according to the [MDN](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf).

For this reason, this fix could be merged only in pre-v1, and for the v1, another solution could be found. 
One of the way I'm thinking about is one I found in Axios, which is implementing a public readonly property on the error like `isYupValidationError` that would be `true`. This would allow to check for `true` and let any falsy value pass through. 

If necessary, I'm willing to also implement it for the pre-v1. This fix is also portable to `master`. 
Please note that the instanceof would allow the library to keep the backward-compatibility, and you would be allowed to be broken on v1 release. 