### PR TITLE
Empty string bug added by SpaceBar fixed

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -94,6 +94,29 @@ export default class StringSchema<
       }),
     );
   }
+  
+  /*
+  CommentId: Zain:#1 (open)
+  Bug Detail: 
+  During Validation of any form Press Space bar and submit form, Form will be Submit,Empty String Should Validate False
+  */
+  stringNotEmpty(message?: Message<any>) {
+    return super.required(message).withMutation((schema: this) =>
+      schema.test({
+        message: message || mixedLocale.required,
+        name: 'required',
+        skipAbsent: true,
+        test: function(value) {
+          if(value !== undefined){
+              return value.trim() !== "";
+          } else if(value === undefined){
+              return false
+          }
+      },  
+      }),
+    );
+  }
+  //  CommentId: Zain:#1 (Closed)
 
   notRequired() {
     return super.notRequired().withMutation((schema: this) => {


### PR DESCRIPTION
During Validation of any form Press the Space bar and submit a form, Form will be Submit, Empty String Should Validate False,
I always write a custom method to validate String with the Required method whenever I use Yup for validation. Today I just thought about fork this Repo and want to contribute, if there is any wrong Please let me know. I'm a beginner.