### PR TITLE
Fix addMethod base type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,12 @@ import Schema, {
 } from './schema';
 import type { InferType, Message } from './types';
 
-function addMethod<T extends Schema>(
+function addMethod<T extends AnySchema>(
   schemaType: (...arg: any[]) => T,
   name: string,
   fn: (this: T, ...args: any[]) => T,
 ): void;
-function addMethod<T extends new (...args: any) => Schema>(
+function addMethod<T extends new (...args: any) => AnySchema>(
   schemaType: T,
   name: string,
   fn: (this: InstanceType<T>, ...args: any[]) => InstanceType<T>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,12 @@ import Schema, {
 } from './schema';
 import type { InferType, Message } from './types';
 
-function addMethod<T extends AnySchema>(
+function addMethod<T extends Schema>(
   schemaType: (...arg: any[]) => T,
   name: string,
   fn: (this: T, ...args: any[]) => T,
 ): void;
-function addMethod<T extends new (...args: any) => AnySchema>(
+function addMethod<T extends new (...args: any) => Schema>(
   schemaType: T,
   name: string,
   fn: (this: InstanceType<T>, ...args: any[]) => InstanceType<T>,

--- a/test/types/types.ts
+++ b/test/types/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable no-unused-labels */
 import {
+  addMethod,
   array,
   number,
   string,
@@ -1035,4 +1036,14 @@ reach: {
 
   // $ExpectType Reference<"foo"> | ISchema<"foo", AnyObject, any, any>
   const _3 = reach(obj, 'ref');
+}
+
+AddMethod: {
+  // NOTE: if this changes, update the doc https://github.com/jquense/yup#extending-built-in-schema-with-new-methods
+  addMethod(string, 'append', function append(appendStr: string) {
+    return this.transform((value) => `${value}${appendStr}`);
+  });
+  addMethod(string, 'mixed', function append(appendStr: string) {
+    return this.transform((value) => `${value}${appendStr}`);
+  });
 }

--- a/test/types/types.ts
+++ b/test/types/types.ts
@@ -1040,10 +1040,10 @@ reach: {
 
 AddMethod: {
   // NOTE: if this changes, update the doc https://github.com/jquense/yup#extending-built-in-schema-with-new-methods
-  addMethod(string, 'append', function append(appendStr: string) {
+  addMethod(string, 'stringAppend', function append(appendStr: string) {
     return this.transform((value) => `${value}${appendStr}`);
   });
-  addMethod(string, 'mixed', function append(appendStr: string) {
+  addMethod(mixed, 'mixedAppend', function append(appendStr: string) {
     return this.transform((value) => `${value}${appendStr}`);
   });
 }


### PR DESCRIPTION
I also note that there are no ci/automated tests for the types file.  I'm not sure what the plan is here, but I do see that the conversion of the `addMethod` test from `yup.js` could be challenging in that regard because it is dynamic.  ~~Perhaps it is best to get a typecheck done on this `test/types/types.ts` file if there are no other solutions?  Something like https://github.com/i18next/i18next/blob/master/package.json#L109 or better?~~ I see type checking is done via jest.

Regardless, this PR gets `addMethod` into a working state on the 1.0.0-beta.7. 