### PR TITLE
Export ValidateOptions for external reuse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import Schema, {
   SchemaFieldDescription,
   SchemaDescription,
 } from './schema';
-import type { InferType, Message } from './types';
+import type { InferType, Message, ValidateOptions } from './types';
 
 function addMethod<T extends AnySchema>(
   schemaType: (...arg: any[]) => T,
@@ -66,6 +66,7 @@ export type {
   SchemaFieldDescription,
   SchemaDescription,
   LocaleObject,
+  ValidateOptions
 };
 
 export {


### PR DESCRIPTION
We have been using this type from the general release, and I see no reason to hide it, given that `InternalOptions` serves this purpose.