### PR TITLE
fix: string().notRequired()

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -97,7 +97,7 @@ export default class StringSchema<
 
   notRequired() {
     return super.notRequired().withMutation((schema: this) => {
-      schema.tests.filter((t) => t.OPTIONS!.name !== 'required');
+      schema.tests = schema.tests.filter((t) => t.OPTIONS!.name !== 'required');
       return schema;
     });
   }

--- a/test/string.ts
+++ b/test/string.ts
@@ -94,6 +94,15 @@ describe('String types', () => {
     ]);
   });
 
+  it('should handle NOTREQUIRED correctly', function () {
+    let v = string().required().notRequired();
+
+    return Promise.all([
+      expect(v.isValid(undefined)).resolves.toBe(true),
+      expect(v.isValid('')).resolves.toBe(true),
+    ]);
+  });
+
   it('should check MATCHES correctly', function () {
     let v = string().matches(/(hi|bye)/, 'A message');
 


### PR DESCRIPTION
In a project, we need to undo some `.required()` fields in `.when()`-conditions, but for `string()` that does not work 🙈.

This should fix it. 🤞 

Thank you for your work maintaining this validation library (coming here from the Formik-recommendation). 💚 