### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1236,7 +1236,7 @@ anything that isn't `null` or `undefined` which yup treats distinctly.
 ```ts
 import { mixed, InferType } from 'yup';
 
-let schema = mixed().null;
+let schema = mixed().nullable();
 
 schema.validateSync('string'); // 'string';
 


### PR DESCRIPTION
It appears that `mixed().null` does not exist, TypeScript error:

```
Property 'null' does not exist on type 'MixedSchema<AnyPresentValue | undefined, AnyObject, undefined, "">'.
```