### PR TITLE
feat: add schema.asContext and array.indexContextKey

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -192,11 +192,6 @@ export default abstract class Schema<
     });
   }
 
-  // TODO: remove
-  get _type() {
-    return this.type;
-  }
-
   clone(spec?: Partial<SchemaSpec<any>>): this {
     if (this._mutate) {
       if (spec) Object.assign(this.spec, spec);

--- a/test/array.ts
+++ b/test/array.ts
@@ -208,4 +208,18 @@ describe('Array types', () => {
       array().of(number().required()).isValid(sparseArray),
     ).resolves.toEqual(false);
   });
+
+  it('should work with asContext and indexContextKey', async () => {
+    const schema = array()
+      .asContext('root')
+      .indexContextKey('idx')
+      .of(
+        number().when(['$root', '$idx'], ([root, idx], schema) =>
+          idx > 0 ? schema.moreThan(root[idx - 1]) : schema,
+        ),
+      );
+
+    await expect(schema.isValid([1, 2, 3])).resolves.toEqual(true);
+    await expect(schema.isValid([1, 3, 2])).resolves.toEqual(false);
+  });
 });

--- a/test/object.ts
+++ b/test/object.ts
@@ -1071,4 +1071,17 @@ describe('Object types', () => {
       await inst.omit(['age', 'name']).validate({ color: 'mauve' }),
     ).toEqual({ color: 'mauve' });
   });
+
+  it('should work with asContext', async () => {
+    let inst = object({
+      foo: number(),
+      inner: object({
+        bar: number().moreThan(ref('$root.foo')),
+      }),
+    }).asContext('root');
+
+    await expect(inst.isValid({ foo: 3, inner: { bar: 5 } })).resolves.toBe(
+      true,
+    );
+  });
 });


### PR DESCRIPTION
This is a proof of concept to give more access in the schema to the parent/any element in the schema. Adds two new methods: 

- `schema.asContext`

Adds the whole value as a context, this allows to access any random property of the schema from any node or sub property.

Eg

```tsx
let schema = object()
  .asContext('root')
  .shape({
    foo: number(),
    inner: object({
      bar: number().moreThan(ref('$root.foo')),
    }),
  });

schema.isValid({ foo: 3, inner: { bar: 5 } }); // true
schema.isValid({ foo: 3, inner: { bar: 2 } }); // false
```

- `array.indexContextKey`

Adds the current element index as a context value, this is useful when comparing the element to previous elements in the array

Eg to make sure array is sorted

```tsx
const schema = array()
  .asContext('root')
  .indexContextKey('idx')
  .of(
    number().when(['$root', '$idx'], ([root, idx], schema) =>
      idx > 0 ? schema.moreThan(root[idx - 1]) : schema,
    ),
  );

schema.isValid([1, 2, 3]); // true
schema.isValid([1, 3, 2]); // false

```