### PR TITLE
Add getDefault results to the describe method

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ let schema = object({
 schema.describe({ value: { isBig: true } });
 ```
 
-And below is are the description types, which differ a bit depending on the schema type.
+And below are the description types, which differ a bit depending on the schema type.
 
 ```ts
 interface SchemaDescription {
@@ -690,6 +690,7 @@ interface SchemaDescription {
   meta: object | undefined;
   oneOf: unknown[];
   notOneOf: unknown[];
+  default?: unknown;
   nullable: boolean;
   optional: boolean;
   tests: Array<{ name?: string; params: ExtraParams | undefined }>;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -126,6 +126,7 @@ export interface SchemaDescription {
   meta: object | undefined;
   oneOf: unknown[];
   notOneOf: unknown[];
+  default?: unknown;
   nullable: boolean;
   optional: boolean;
   tests: Array<{ name?: string; params: ExtraParams | undefined }>;
@@ -917,6 +918,7 @@ export default abstract class Schema<
       label,
       optional,
       nullable,
+      default: next.getDefault(options),
       type: next.type,
       oneOf: next._whitelist.describe(),
       notOneOf: next._blacklist.describe(),

--- a/test/mixed.ts
+++ b/test/mixed.ts
@@ -956,6 +956,7 @@ describe('Mixed Types ', () => {
         foo: array(number().integer()).required(),
         bar: string()
           .max(2)
+          .default(()=> 'a')
           .meta({ input: 'foo' })
           .label('str!')
           .oneOf(['a', 'b'])
@@ -972,6 +973,11 @@ describe('Mixed Types ', () => {
         type: 'object',
         meta: undefined,
         label: undefined,
+        default: {
+          foo: undefined,
+          bar: 'a',
+          lazy: undefined
+        },
         nullable: false,
         optional: true,
         tests: [],
@@ -982,11 +988,13 @@ describe('Mixed Types ', () => {
             type: 'lazy',
             meta: undefined,
             label: undefined,
+            default: undefined,
           },
           foo: {
             type: 'array',
             meta: undefined,
             label: undefined,
+            default: undefined,
             nullable: false,
             optional: false,
             tests: [],
@@ -996,6 +1004,7 @@ describe('Mixed Types ', () => {
               type: 'number',
               meta: undefined,
               label: undefined,
+              default: undefined,
               nullable: false,
               optional: true,
               oneOf: [],
@@ -1011,6 +1020,7 @@ describe('Mixed Types ', () => {
           bar: {
             type: 'string',
             label: 'str!',
+            default: 'a',
             tests: [{ name: 'max', params: { max: 2 } }],
             meta: {
               input: 'foo',
@@ -1034,6 +1044,11 @@ describe('Mixed Types ', () => {
         type: 'object',
         meta: undefined,
         label: undefined,
+        default: {
+          foo: undefined,
+          bar: 'a',
+          lazy: undefined
+        },
         nullable: false,
         optional: true,
         tests: [],
@@ -1044,6 +1059,7 @@ describe('Mixed Types ', () => {
             type: 'string',
             meta: undefined,
             label: undefined,
+            default: undefined,
             nullable: true,
             optional: true,
             oneOf: [],
@@ -1054,6 +1070,7 @@ describe('Mixed Types ', () => {
             type: 'array',
             meta: undefined,
             label: undefined,
+            default: undefined,
             nullable: false,
             optional: false,
             tests: [],
@@ -1063,6 +1080,7 @@ describe('Mixed Types ', () => {
               type: 'number',
               meta: undefined,
               label: undefined,
+              default: undefined,
               nullable: false,
               optional: true,
               oneOf: [],
@@ -1078,6 +1096,7 @@ describe('Mixed Types ', () => {
           bar: {
             type: 'string',
             label: 'str!',
+            default: 'a',
             tests: [{ name: 'max', params: { max: 2 } }],
             meta: {
               input: 'foo',


### PR DESCRIPTION
This PR addresses https://github.com/jquense/yup/issues/1886.

The `describe()` method now returns the result of `schema.getDefault()`. I am currently updating a library that converts Yup schemas to JSONSchemas. The new `optional` and `nullable` flags have been helpful. The addition of the `default` would be super helpful as well.

Let me know if you have any questions.