### PR TITLE
The notMatches method is required.

### DIFF
--- a/src/locale.ts
+++ b/src/locale.ts
@@ -17,6 +17,7 @@ export interface StringLocale {
   min?: Message<{ min: number }>;
   max?: Message<{ max: number }>;
   matches?: Message<{ regex: RegExp }>;
+  notMatches?: Message<{ regex: RegExp }>;
   email?: Message<{ regex: RegExp }>;
   url?: Message<{ regex: RegExp }>;
   uuid?: Message<{ regex: RegExp }>;

--- a/src/string.ts
+++ b/src/string.ts
@@ -176,6 +176,33 @@ export default class StringSchema<
         (value === '' && excludeEmptyString) || value!.search(regex) !== -1,
     });
   }
+  
+  notMatches(regex: RegExp, options?: MatchOptions | MatchOptions['message']) {
+    let excludeEmptyString = false;
+    let message;
+    let name;
+
+    if (options) {
+      if (typeof options === 'object') {
+        ({
+          excludeEmptyString = false,
+          message,
+          name,
+        } = options as MatchOptions);
+      } else {
+        message = options;
+      }
+    }
+
+    return this.test({
+      name: name || 'notMatches',
+      message: message || locale.notMatches,
+      params: { regex },
+      skipAbsent: true,
+      test: (value: Maybe<string>) =>
+        (value === '' && excludeEmptyString) || value!.search(regex) === -1,
+    });
+  }
 
   email(message = locale.email) {
     return this.matches(rEmail, {


### PR DESCRIPTION
When we need to use a library like emoji-regex to make sure there are no emojis, we need notMatches.

There may be a way to change the regular expression, but I think it is necessary because it can be cumbersome to change the regular expression.

Like notRequired

