### PR TITLE
Fix regex test for email addresses without tld

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -19,7 +19,7 @@ import Schema from './schema';
 // Taken from HTML spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 let rEmail =
   // eslint-disable-next-line
-  /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
 
 let rUrl =
   // eslint-disable-next-line


### PR DESCRIPTION
The current regex in place does not properly validate when a TLD is omitted, for example this is valid: `email@site`
By making the last group in the regex required at least one time instead of zero, the issue is solved.

Fixes https://github.com/jquense/yup/issues/1909