### PR TITLE
Allow explicit type to be defined for object()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules\\typescript\\lib"
-}

--- a/src/object.ts
+++ b/src/object.ts
@@ -79,10 +79,17 @@ function unknown(ctx: ObjectSchema<any, any, any>, value: any) {
 
 const defaultSort = sortByKeyOrder([]);
 
-export function create<TIn extends AnyObject, C extends Maybe<AnyObject> = AnyObject, S extends Shape<TIn, C> = Shape<TIn, C>>(spec: S): ObjectSchema<_<TypeFromShape<S, C>>, C, _<DefaultFromShape<S>>>;
-export function create(): ObjectSchema<{}, AnyObject, _<DefaultFromShape<{}>>>;
-export function create<TIn extends AnyObject, C extends Maybe<AnyObject> = AnyObject>(spec?: Shape<TIn, C>) {
-  type TDefault = _<DefaultFromShape<TIn>>;
+export function create(): ObjectSchema<{}, AnyObject, {}>;
+
+export function create<
+  TIn extends AnyObject, 
+  C extends Maybe<AnyObject> = AnyObject, 
+  S extends Shape<TIn, C> = Shape<TIn, C>
+>(spec: S): ObjectSchema<_<TypeFromShape<S, C>>, C, _<DefaultFromShape<S>>>;
+
+export function create<C extends Maybe<AnyObject> = AnyObject, S extends ObjectShape = {}>(spec?: S) {
+  type TIn = _<TypeFromShape<S, C>>;
+  type TDefault = _<DefaultFromShape<S>>;
 
   return new ObjectSchema<TIn, C, TDefault>(spec as any);
 }

--- a/src/object.ts
+++ b/src/object.ts
@@ -79,12 +79,10 @@ function unknown(ctx: ObjectSchema<any, any, any>, value: any) {
 
 const defaultSort = sortByKeyOrder([]);
 
-export function create<
-  C extends Maybe<AnyObject> = AnyObject,
-  S extends ObjectShape = {},
->(spec?: S) {
-  type TIn = _<TypeFromShape<S, C>>;
-  type TDefault = _<DefaultFromShape<S>>;
+export function create<TIn extends AnyObject, C extends Maybe<AnyObject> = AnyObject, S extends Shape<TIn, C> = Shape<TIn, C>>(spec: S): ObjectSchema<_<TypeFromShape<S, C>>, C, _<DefaultFromShape<S>>>;
+export function create(): ObjectSchema<{}, AnyObject, _<DefaultFromShape<{}>>>;
+export function create<TIn extends AnyObject, C extends Maybe<AnyObject> = AnyObject>(spec?: Shape<TIn, C>) {
+  type TDefault = _<DefaultFromShape<TIn>>;
 
   return new ObjectSchema<TIn, C, TDefault>(spec as any);
 }

--- a/src/object.ts
+++ b/src/object.ts
@@ -399,7 +399,7 @@ export default class ObjectSchema<
     additions: U,
     excludes: readonly [string, string][] = [],
   ) {
-    type UIn = TypeFromShape<U, TContext>;
+    type UIn = MakePartial<TypeFromShape<U, TContext>>;
     type UDefault = Extract<TFlags, 'd'> extends never
       ? // not defaulted then assume the default is derived and should be merged
         _<TDefault & DefaultFromShape<U>>

--- a/src/object.ts
+++ b/src/object.ts
@@ -87,7 +87,16 @@ type IsAnonymousObject<T> = string | number extends keyof T ? true : false;
 
 // Decides between an explicitly defined target type versus resolving the shape from a schema spec
 type TypeFromTarget<Target, S extends ObjectShape> = true extends IsAnonymousObject<Target>
-  ? MakePartial<{ [K in keyof S]: S[K] extends Reference<infer R> ? R : S[K] extends ISchema<any> ? ResolveStrip<S[K]> : S[K] }>
+  ? MakePartial<{ 
+    [K in keyof S]: 
+      // If Reference, choose reference type
+      S[K] extends Reference<infer R> 
+      ? R 
+      // If schema, resolve the schema
+      : S[K] extends ISchema<any> 
+        ? ResolveStrip<S[K]> 
+        : S[K] 
+  }>
   : Target;
 
 export function create(): ObjectSchema<{}, AnyObject, {}>;
@@ -375,7 +384,7 @@ export default class ObjectSchema<
   private setFields<TInNext extends Maybe<AnyObject>, TDefaultNext>(
     shape: Shape<TInNext, TContext>,
     excludedEdges?: readonly [string, string][],
-  ): ObjectSchema<TInNext, TContext, TDefaultNext, TFlags> {
+  ): ObjectSchema<_<TInNext>, TContext, TDefaultNext, TFlags> {
     let next = this.clone() as any;
     next.fields = shape;
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -113,22 +113,11 @@ describe('Object types', () => {
         options: array(optionChoiceSchema).required()
       });
 
-      const optionChoiceSchema2 = object({
-        optionValue: number(),
-        optionalValue: number().optional(),
-      });
-
-      const choiceListSchema2 = object({
-        options: array(optionChoiceSchema2).required(),
-        date: date(),
-      });
-
       const listExample: ChoiceList = {
         options: [{ optionValue: 42 }],
       };
 
       await expect(choiceListSchema.isValid(listExample)).resolves.toBe(true);
-      await expect(choiceListSchema2.isValid(listExample)).resolves.toBe(true);
     });
   });
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -94,6 +94,28 @@ describe('Object types', () => {
       };
 
       await expect(inst.isValid(obj)).resolves.toBe(true);
+
+      interface OptionChoice {
+        optionValue: number | undefined;
+      }
+
+      interface ChoiceList {
+        options: OptionChoice[];
+      }
+
+      const optionChoiceSchema = object<OptionChoice>({
+        optionValue: number(),
+      });
+
+      const choiceListSchema = object<ChoiceList>({
+        options: array(optionChoiceSchema).required()
+      });
+
+      const listExample: ChoiceList = {
+        options: [{ optionValue: 42 }],
+      };
+
+      await expect(choiceListSchema.isValid(listExample)).resolves.toBe(true);
     });
   });
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -97,6 +97,7 @@ describe('Object types', () => {
 
       interface OptionChoice {
         optionValue: number | undefined;
+        optionalValue?: number;
       }
 
       interface ChoiceList {
@@ -105,11 +106,21 @@ describe('Object types', () => {
 
       const optionChoiceSchema = object<OptionChoice>({
         optionValue: number(),
+        optionalValue: number(),
       });
 
       const choiceListSchema = object<ChoiceList>({
-        // Error says "Property 'optionValue' is optional in type '{ optionValue?: number | undefined; }' but required in type 'OptionChoice'"
         options: array(optionChoiceSchema).required()
+      });
+
+      const optionChoiceSchema2 = object({
+        optionValue: number(),
+        optionalValue: number().optional(),
+      });
+
+      const choiceListSchema2 = object({
+        options: array(optionChoiceSchema2).required(),
+        date: date(),
       });
 
       const listExample: ChoiceList = {
@@ -117,6 +128,7 @@ describe('Object types', () => {
       };
 
       await expect(choiceListSchema.isValid(listExample)).resolves.toBe(true);
+      await expect(choiceListSchema2.isValid(listExample)).resolves.toBe(true);
     });
   });
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -108,6 +108,7 @@ describe('Object types', () => {
       });
 
       const choiceListSchema = object<ChoiceList>({
+        // Error says "Property 'optionValue' is optional in type '{ optionValue?: number | undefined; }' but required in type 'OptionChoice'"
         options: array(optionChoiceSchema).required()
       });
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -83,6 +83,18 @@ describe('Object types', () => {
 
       expect(inst.cast(obj)).toBe(obj);
     });
+
+    it('should allow explicitly defined type', async () => {
+      const inst = object<{ foo: number }>({ 
+        foo: number().required(),
+      });
+
+      const obj = {
+        foo: 42
+      };
+
+      await expect(inst.isValid(obj)).resolves.toBe(true);
+    });
   });
 
   describe('validation', () => {

--- a/test/types/types.ts
+++ b/test/types/types.ts
@@ -858,7 +858,7 @@ Object: {
     name: string(),
   });
 
-  // $ExpectType { name?: string | undefined; other: string; field: number; }
+  // $ExpectType { other: string; field: number; name?: string | undefined; }
   merge.cast({});
 
   // $ExpectType number
@@ -878,10 +878,10 @@ Object: {
       name: string(),
     }).nullable();
 
-    // $ExpectType { name?: string | undefined; other: string; field: number; } | null
+    // $ExpectType { other: string; field: number; name?: string | undefined; } | null
     obj1.concat(obj2).cast('');
 
-    // $ExpectType { name?: string | undefined; other: string; field: number; }
+    // $ExpectType { other: string; field: number; name?: string | undefined; }
     obj1.nullable().concat(obj2.nonNullable()).cast('');
 
     // $ExpectType { field: 1; other: ""; name: undefined; }
@@ -897,7 +897,7 @@ Object: {
         .default(undefined)
         .optional(),
     });
-
+    
     // $ExpectType { h: number; } | undefined
     optionalNonDefaultedObj.cast({}).nested;
   }


### PR DESCRIPTION
Relates to #2027

This change would allow us to explicit define the target type for `object()` ahead of time via the first generic arg, allowing for more direct intellisense feedback in TypeScript.

Example:
![image](https://github.com/jquense/yup/assets/29075873/04ad863a-8a1f-4aa3-a202-3cd08c8ab48a)

Please note, this change is fully backwards compatible.  The generic arg is optional and the output type is still inferred properly if the not provided.
