### PR TITLE
Allow parent resolve before describe.

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -268,7 +268,7 @@ export default class ArraySchema<
     );
   }
 
-  describe(options?: ResolveOptions<TContext>) {
+  protected _describe(options?: ResolveOptions<TContext>) {
     let base = super.describe(options) as SchemaInnerTypeDescription;
     if (this.innerType) {
       let innerOptions = options;
@@ -282,6 +282,11 @@ export default class ArraySchema<
       base.innerType = this.innerType.describe(innerOptions);
     }
     return base;
+  }
+
+  describe(options?: ResolveOptions<TContext>) {
+    const next = options ? this.resolve(options) : this;
+    return next._describe(options)
   }
 }
 

--- a/src/array.ts
+++ b/src/array.ts
@@ -268,9 +268,10 @@ export default class ArraySchema<
     );
   }
 
-  protected _describe(options?: ResolveOptions<TContext>) {
-    let base = super.describe(options) as SchemaInnerTypeDescription;
-    if (this.innerType) {
+  describe(options?: ResolveOptions<TContext>) {
+    const next = (options ? this.resolve(options) : this).clone();
+    const base = super.describe(options) as SchemaInnerTypeDescription;
+    if (next.innerType) {
       let innerOptions = options;
       if (innerOptions?.value) {
         innerOptions = {
@@ -279,14 +280,9 @@ export default class ArraySchema<
           value: innerOptions.value[0],
         };
       }
-      base.innerType = this.innerType.describe(innerOptions);
+      base.innerType = next.innerType.describe(innerOptions);
     }
     return base;
-  }
-
-  describe(options?: ResolveOptions<TContext>) {
-    const next = options ? this.resolve(options) : this;
-    return next._describe(options)
   }
 }
 

--- a/src/object.ts
+++ b/src/object.ts
@@ -507,10 +507,11 @@ export default class ObjectSchema<
     return this.transformKeys((key) => snakeCase(key).toUpperCase());
   }
 
-  protected _describe(options?: ResolveOptions<TContext>) {
-    let base = super.describe(options) as SchemaObjectDescription;
+  describe(options?: ResolveOptions<TContext>) {
+    const next = (options ? this.resolve(options) : this).clone();
+    const base = super.describe(options) as SchemaObjectDescription;
     base.fields = {};
-    for (const [key, value] of Object.entries(this.fields)) {
+    for (const [key, value] of Object.entries(next.fields)) {
       let innerOptions = options;
       if (innerOptions?.value) {
         innerOptions = {
@@ -522,11 +523,6 @@ export default class ObjectSchema<
       base.fields[key] = value.describe(innerOptions);
     }
     return base;
-  }
-
-  describe(options?: ResolveOptions<TContext>) {
-    const next = options ? this.resolve(options) : this;
-    return next._describe(options)
   }
 }
 

--- a/src/object.ts
+++ b/src/object.ts
@@ -507,7 +507,7 @@ export default class ObjectSchema<
     return this.transformKeys((key) => snakeCase(key).toUpperCase());
   }
 
-  describe(options?: ResolveOptions<TContext>) {
+  protected _describe(options?: ResolveOptions<TContext>) {
     let base = super.describe(options) as SchemaObjectDescription;
     base.fields = {};
     for (const [key, value] of Object.entries(this.fields)) {
@@ -522,6 +522,11 @@ export default class ObjectSchema<
       base.fields[key] = value.describe(innerOptions);
     }
     return base;
+  }
+
+  describe(options?: ResolveOptions<TContext>) {
+    const next = options ? this.resolve(options) : this;
+    return next._describe(options)
   }
 }
 

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -159,9 +159,10 @@ export default class TupleSchema<
     });
   }
 
-  protected _describe(options?: ResolveOptions<TContext>) {
-    let base = super.describe(options) as SchemaInnerTypeDescription;
-    base.innerType = this.spec.types.map((schema, index) => {
+  describe(options?: ResolveOptions<TContext>) {
+    const next = (options ? this.resolve(options) : this).clone();
+    const base = super.describe(options) as SchemaInnerTypeDescription;
+    base.innerType = next.spec.types.map((schema, index) => {
       let innerOptions = options;
       if (innerOptions?.value) {
         innerOptions = {
@@ -173,11 +174,6 @@ export default class TupleSchema<
       return schema.describe(innerOptions);
     });
     return base;
-  }
-
-  describe(options?: ResolveOptions<TContext>) {
-    const next = options ? this.resolve(options) : this;
-    return next._describe(options)
   }
 }
 

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -159,7 +159,7 @@ export default class TupleSchema<
     });
   }
 
-  describe(options?: ResolveOptions<TContext>) {
+  protected _describe(options?: ResolveOptions<TContext>) {
     let base = super.describe(options) as SchemaInnerTypeDescription;
     base.innerType = this.spec.types.map((schema, index) => {
       let innerOptions = options;
@@ -173,6 +173,11 @@ export default class TupleSchema<
       return schema.describe(innerOptions);
     });
     return base;
+  }
+
+  describe(options?: ResolveOptions<TContext>) {
+    const next = options ? this.resolve(options) : this;
+    return next._describe(options)
   }
 }
 

--- a/test/mixed.ts
+++ b/test/mixed.ts
@@ -967,6 +967,11 @@ describe('Mixed Types ', () => {
             then: (s) => s.defined(),
           }),
         baz: tuple([string(), number()]),
+      })
+      .when(['dummy'], (_, s) => {
+        return s.shape({
+          when: string()
+        })
       });
     });
 
@@ -1087,6 +1092,7 @@ describe('Mixed Types ', () => {
           bar: 'a',
           lazy: undefined,
           baz: undefined,
+          when: undefined,
         },
         nullable: false,
         optional: true,
@@ -1185,6 +1191,17 @@ describe('Mixed Types ', () => {
               },
             ],
           },
+          when: {
+            type: 'string',
+            meta: undefined,
+            label: undefined,
+            default: undefined,
+            notOneOf: [],
+            nullable: false,
+            oneOf: [],
+            optional: true,
+            tests: [],
+          }
         },
       });
     });


### PR DESCRIPTION
Solves: https://github.com/jquense/yup/issues/2050

This PR updates the `object`, `array`, and `tuple` schemas such that they are resolved before being described. This ensures that the `describe` method works for things like `object({...}).when(...)`
