### PR TITLE
Fix date parsing to match docs and support timestamps

### DIFF
--- a/src/util/isodate.js
+++ b/src/util/isodate.js
@@ -16,7 +16,9 @@ export default function parseIsoDate(date) {
     timestamp,
     struct;
 
-  if ((struct = isoReg.exec(date))) {
+  if (!isNaN(new Date(date))) {
+    timestamp = +new Date(date);
+  } else if ((struct = isoReg.exec(date))) {
     // avoid NaN timestamps caused by “undefined” values being passed to Date.UTC
     for (var i = 0, k; (k = numericKeys[i]); ++i) struct[k] = +struct[k] || 0;
 

--- a/test/date.ts
+++ b/test/date.ts
@@ -20,6 +20,7 @@ describe('Date types', () => {
     expect(inst.cast('2016-08-10T11:32:19.2125Z')).toEqual(
       new Date(1470828739212),
     );
+    expect(inst.cast(1411500325000)).toEqual(new Date(1411500325000));
 
     expect(inst.cast(null, { assert: false })).toEqual(null);
   });


### PR DESCRIPTION
The yup documentation states

    The default cast logic of date is pass the value to the Date
    constructor, failing that, it will attempt to parse the date as an
    ISO date string.

which wasn't true and would manifest for timestamps i.e.

    const schema = yup.date();
    schema.validateSync(1411500325000) // Failed to validated

as the cast logic would try Date.parse(1411500325000) which would return an invalid date.