### PR TITLE
#2043 performance improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ const parsedUser = await userSchema.validate(
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Schema basics](#schema-basics)
   - [Parsing: Transforms](#parsing-transforms)
   - [Validation: Tests](#validation-tests)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yup",
-  "version": "1.2.0-dev6",
+  "version": "1.2.0",
   "description": "Dead simple Object schema validation",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yup",
-  "version": "1.2.0",
+  "version": "1.2.0-dev6",
   "description": "Dead simple Object schema validation",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/src/ValidationError.ts
+++ b/src/ValidationError.ts
@@ -55,7 +55,7 @@ export default class ValidationError implements Error {
       if (ValidationError.isError(err)) {
         this.errors.push(...err.errors);
         const innerErrors = err.inner.length ? err.inner : [err];
-        this.inner.splice(this.inner.length, 0, ...innerErrors);
+        this.inner.push(...innerErrors);
       } else {
         this.errors.push(err);
       }

--- a/src/ValidationError.ts
+++ b/src/ValidationError.ts
@@ -69,4 +69,5 @@ export default class ValidationError implements Error {
     if (!disableStack && Error.captureStackTrace)
       Error.captureStackTrace(this, ValidationError);
   }
+  [Symbol.toStringTag] = 'Error';
 }

--- a/src/ValidationError.ts
+++ b/src/ValidationError.ts
@@ -5,7 +5,10 @@ let strReg = /\$\{\s*(\w+)\s*\}/g;
 
 type Params = Record<string, unknown>;
 
-export default class ValidationError extends Error {
+export default class ValidationError implements Error {
+  name: string;
+  message: string;
+  stack?: string | undefined;
   value: any;
   path?: string;
   type?: string;
@@ -38,9 +41,8 @@ export default class ValidationError extends Error {
     value?: any,
     field?: string,
     type?: string,
+    disableStack?: boolean,
   ) {
-    super();
-
     this.name = 'ValidationError';
     this.value = value;
     this.path = field;
@@ -52,7 +54,8 @@ export default class ValidationError extends Error {
     toArray(errorOrErrors).forEach((err) => {
       if (ValidationError.isError(err)) {
         this.errors.push(...err.errors);
-        this.inner = this.inner.concat(err.inner.length ? err.inner : err);
+        const innerErrors = err.inner.length ? err.inner : [err];
+        this.inner.splice(this.inner.length, 0, ...innerErrors);
       } else {
         this.errors.push(err);
       }
@@ -63,6 +66,7 @@ export default class ValidationError extends Error {
         ? `${this.errors.length} errors occurred`
         : this.errors[0];
 
-    if (Error.captureStackTrace) Error.captureStackTrace(this, ValidationError);
+    if (!disableStack && Error.captureStackTrace)
+      Error.captureStackTrace(this, ValidationError);
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -503,11 +503,7 @@ export default abstract class Schema<
 
       test(args!, panicOnce, function finishTestRun(err) {
         if (err) {
-          nestedErrors.splice(
-            nestedErrors.length,
-            0,
-            ...(Symbol.iterator in err ? err : [err]),
-          );
+          Array.isArray(err) ? nestedErrors.push(...err) :  nestedErrors.push(err)
         }
         if (--count <= 0) {
           nextOnce(nestedErrors);
@@ -561,8 +557,7 @@ export default abstract class Schema<
     options?: ValidateOptions<TContext>,
   ): Promise<this['__outputType']> {
     let schema = this.resolve({ ...options, value });
-    let { disableStackTrace = this.spec.disableStackTrace } =
-      options ?? this.spec;
+    let  disableStackTrace  = options?.disableStackTrace ?? schema.spec.disableStackTrace;
 
     return new Promise((resolve, reject) =>
       schema._validate(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -503,7 +503,9 @@ export default abstract class Schema<
 
       test(args!, panicOnce, function finishTestRun(err) {
         if (err) {
-          Array.isArray(err) ? nestedErrors.push(...err) :  nestedErrors.push(err)
+          Array.isArray(err)
+            ? nestedErrors.push(...err)
+            : nestedErrors.push(err);
         }
         if (--count <= 0) {
           nextOnce(nestedErrors);
@@ -557,7 +559,8 @@ export default abstract class Schema<
     options?: ValidateOptions<TContext>,
   ): Promise<this['__outputType']> {
     let schema = this.resolve({ ...options, value });
-    let  disableStackTrace  = options?.disableStackTrace ?? schema.spec.disableStackTrace;
+    let disableStackTrace =
+      options?.disableStackTrace ?? schema.spec.disableStackTrace;
 
     return new Promise((resolve, reject) =>
       schema._validate(
@@ -590,8 +593,8 @@ export default abstract class Schema<
   ): this['__outputType'] {
     let schema = this.resolve({ ...options, value });
     let result: any;
-    let { disableStackTrace = this.spec.disableStackTrace } =
-      options ?? this.spec;
+    let disableStackTrace =
+      options?.disableStackTrace ?? schema.spec.disableStackTrace;
 
     schema._validate(
       value,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -43,6 +43,7 @@ export type SchemaSpec<TDefault> = {
   strip?: boolean;
   strict?: boolean;
   recursive?: boolean;
+  disableStackTrace?: boolean;
   label?: string | undefined;
   meta?: SchemaMetadata;
 };
@@ -191,6 +192,7 @@ export default abstract class Schema<
       strict: false,
       abortEarly: true,
       recursive: true,
+      disableStackTrace: false,
       nullable: false,
       optional: true,
       coerce: true,
@@ -345,6 +347,8 @@ export default abstract class Schema<
       strict: options.strict ?? this.spec.strict,
       abortEarly: options.abortEarly ?? this.spec.abortEarly,
       recursive: options.recursive ?? this.spec.recursive,
+      disableStackTrace:
+        options.disableStackTrace ?? this.spec.disableStackTrace,
     };
   }
 
@@ -499,7 +503,11 @@ export default abstract class Schema<
 
       test(args!, panicOnce, function finishTestRun(err) {
         if (err) {
-          nestedErrors = nestedErrors.concat(err);
+          nestedErrors.splice(
+            nestedErrors.length,
+            0,
+            ...(Symbol.iterator in err ? err : [err]),
+          );
         }
         if (--count <= 0) {
           nextOnce(nestedErrors);
@@ -553,6 +561,8 @@ export default abstract class Schema<
     options?: ValidateOptions<TContext>,
   ): Promise<this['__outputType']> {
     let schema = this.resolve({ ...options, value });
+    let { disableStackTrace = this.spec.disableStackTrace } =
+      options ?? this.spec;
 
     return new Promise((resolve, reject) =>
       schema._validate(
@@ -563,7 +573,16 @@ export default abstract class Schema<
           reject(error);
         },
         (errors, validated) => {
-          if (errors.length) reject(new ValidationError(errors!, validated));
+          if (errors.length)
+            reject(
+              new ValidationError(
+                errors!,
+                validated,
+                undefined,
+                undefined,
+                disableStackTrace,
+              ),
+            );
           else resolve(validated as this['__outputType']);
         },
       ),
@@ -576,6 +595,8 @@ export default abstract class Schema<
   ): this['__outputType'] {
     let schema = this.resolve({ ...options, value });
     let result: any;
+    let { disableStackTrace = this.spec.disableStackTrace } =
+      options ?? this.spec;
 
     schema._validate(
       value,
@@ -585,7 +606,14 @@ export default abstract class Schema<
         throw error;
       },
       (errors, validated) => {
-        if (errors.length) throw new ValidationError(errors!, value);
+        if (errors.length)
+          throw new ValidationError(
+            errors!,
+            value,
+            undefined,
+            undefined,
+            disableStackTrace,
+          );
         result = validated;
       },
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,10 @@ export interface ValidateOptions<TContext = {}> {
    */
   recursive?: boolean;
   /**
+   * When true ValidationError instance won't include stack trace information. Default - false
+   */
+  disableStackTrace?: boolean;
+  /**
    * Any context needed for validating schema conditions (see: when())
    */
   context?: TContext;

--- a/src/util/createValidation.ts
+++ b/src/util/createValidation.ts
@@ -22,6 +22,7 @@ export type CreateErrorOptions = {
   message?: Message<any>;
   params?: ExtraParams;
   type?: string;
+  disableStackTrace?: boolean;
 };
 
 export type TestContext<TContext = {}> = {
@@ -79,7 +80,12 @@ export default function createValidation(config: {
     next: NextCallback,
   ) {
     const { name, test, params, message, skipAbsent } = config;
-    let { parent, context, abortEarly = schema.spec.abortEarly } = options;
+    let {
+      parent,
+      context,
+      abortEarly = schema.spec.abortEarly,
+      disableStackTrace = schema.spec.disableStackTrace,
+    } = options;
 
     function resolve<T>(item: T | Reference<T>) {
       return Ref.isRef(item) ? item.getValue(value, parent, context) : item;
@@ -105,6 +111,7 @@ export default function createValidation(config: {
         value,
         nextParams.path,
         overrides.type || name,
+        overrides.disableStackTrace ?? disableStackTrace,
       );
       error.params = nextParams;
       return error;

--- a/test/array.ts
+++ b/test/array.ts
@@ -1,4 +1,12 @@
-import { string, number, object, array, StringSchema, AnySchema } from '../src';
+import {
+  string,
+  number,
+  object,
+  array,
+  StringSchema,
+  AnySchema,
+  ValidationError,
+} from '../src';
 
 describe('Array types', () => {
   describe('casting', () => {
@@ -56,6 +64,9 @@ describe('Array types', () => {
 
     let merged = array(number()).concat(array(number().required()));
 
+    const ve = new ValidationError('');
+    // expect(ve.toString()).toBe('[object Error]');
+    expect(Object.prototype.toString.call(ve)).toBe('[object Error]');
     expect((merged.innerType as AnySchema).type).toBe('number');
 
     await expect(merged.validateAt('[0]', undefined)).rejects.toThrowError();


### PR DESCRIPTION
Resolves performance issues for large data validation described at #2043:

- Arrays of ValidationError
  - Mutate the array with splice instead of using concat
  - ValidationError class
- Add the new option "disableStackTrace" to stop capturing stack trace when instantiating ValidationError
  - Stop ValidationError extending Error, so no need to call super() when instantiating ValidationError

This PR also fix the issue on ValidationError that broke several tests in #2044 