### PR TITLE
fix: add optional message to nonNullable schema methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ const parsedUser = await userSchema.validate(
     - [`Schema.withMutation(builder: (current: Schema) => void): void`](#schemawithmutationbuilder-current-schema--void-void)
     - [`Schema.default(value: any): Schema`](#schemadefaultvalue-any-schema)
     - [`Schema.getDefault(options?: object): Any`](#schemagetdefaultoptions-object-any)
-    - [`Schema.nullable(): Schema`](#schemanullable-schema)
-    - [`Schema.nonNullable(): Schema`](#schemanonnullable-schema)
+    - [`Schema.nullable(message?: string | function): Schema`](#schemanullable-schema)
+    - [`Schema.nonNullable(message?: string | function): Schema`](#schemanonnullable-schema)
     - [`Schema.defined(): Schema`](#schemadefined-schema)
     - [`Schema.optional(): Schema`](#schemaoptional-schema)
     - [`Schema.required(message?: string | function): Schema`](#schemarequiredmessage-string--function-schema)
@@ -946,7 +946,7 @@ yup.date.default(() => new Date()); // also helpful for defaults that change ove
 
 Retrieve a previously set default value. `getDefault` will resolve any conditions that may alter the default. Optionally pass `options` with `context` (for more info on `context` see `Schema.validate`).
 
-#### `Schema.nullable(): Schema`
+#### `Schema.nullable(message?: string | function): Schema`
 
 Indicates that `null` is a valid value for the schema. Without `nullable()`
 `null` is treated as a different type and will fail `Schema.isType()` checks.
@@ -959,7 +959,7 @@ schema.cast(null); // null
 InferType<typeof schema>; // number | null
 ```
 
-#### `Schema.nonNullable(): Schema`
+#### `Schema.nonNullable(message?: string | function): Schema`
 
 The opposite of `nullable`, removes `null` from valid type values for the schema.
 **Schema are non nullable by default**.

--- a/src/array.ts
+++ b/src/array.ts
@@ -307,7 +307,9 @@ export default interface ArraySchema<
   notRequired(): ArraySchema<Maybe<TIn>, TContext, TDefault, TFlags>;
 
   nullable(msg?: Message): ArraySchema<TIn | null, TContext, TDefault, TFlags>;
-  nonNullable(): ArraySchema<NotNull<TIn>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message,
+  ): ArraySchema<NotNull<TIn>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,

--- a/src/date.ts
+++ b/src/date.ts
@@ -134,7 +134,9 @@ export default interface DateSchema<
   notRequired(): DateSchema<Maybe<TType>, TContext, TDefault, TFlags>;
 
   nullable(msg?: Message): DateSchema<TType | null, TContext, TDefault, TFlags>;
-  nonNullable(): DateSchema<NotNull<TType>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message,
+  ): DateSchema<NotNull<TType>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,

--- a/src/mixed.ts
+++ b/src/mixed.ts
@@ -73,7 +73,9 @@ export default interface MixedSchema<
     msg?: Message,
   ): MixedSchema<TType | null, TContext, TDefault, TFlags>;
 
-  nonNullable(): MixedSchema<Exclude<TType, null>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message,
+  ): MixedSchema<Exclude<TType, null>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,

--- a/src/number.ts
+++ b/src/number.ts
@@ -192,7 +192,9 @@ export default interface NumberSchema<
   nullable(
     msg?: Message,
   ): NumberSchema<TType | null, TContext, TDefault, TFlags>;
-  nonNullable(): NumberSchema<NotNull<TType>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message,
+  ): NumberSchema<NotNull<TType>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,

--- a/src/object.ts
+++ b/src/object.ts
@@ -112,7 +112,9 @@ export default interface ObjectSchema<
   notRequired(): ObjectSchema<Maybe<TIn>, TContext, TDefault, TFlags>;
 
   nullable(msg?: Message): ObjectSchema<TIn | null, TContext, TDefault, TFlags>;
-  nonNullable(): ObjectSchema<NotNull<TIn>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message,
+  ): ObjectSchema<NotNull<TIn>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,

--- a/src/string.ts
+++ b/src/string.ts
@@ -288,9 +288,11 @@ export default interface StringSchema<
   notRequired(): StringSchema<Maybe<TType>, TContext, TDefault, TFlags>;
 
   nullable(
-    msg?: Message<any>,
+    msg?: Message,
   ): StringSchema<TType | null, TContext, TDefault, TFlags>;
-  nonNullable(): StringSchema<NotNull<TType>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message
+  ): StringSchema<NotNull<TType>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -58,7 +58,9 @@ export default interface TupleSchema<
   nullable(
     msg?: Message,
   ): TupleSchema<TType | null, TContext, TDefault, TFlags>;
-  nonNullable(): TupleSchema<NotNull<TType>, TContext, TDefault, TFlags>;
+  nonNullable(
+    msg?: Message
+  ): TupleSchema<NotNull<TType>, TContext, TDefault, TFlags>;
 
   strip(
     enabled: false,


### PR DESCRIPTION
Fixes https://github.com/jquense/yup/issues/2069

Adds an optional `msg?: Message` argument to `nonNullable` method on every schema object. The argument is already supported by the [base Schema class](https://github.com/jquense/yup/blob/master/src/schema.ts#L713), and we only need to pass it properly with TypeScript.

Also updates `nullable` and `nonNullable` signatures in `README.md`.