### PR TITLE
Fixes a typo in the asNestedTest() path rendering logic causing issue #2156

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -546,7 +546,7 @@ export default abstract class Schema<
       [isIndex ? 'index' : 'key']: k,
       path:
         isIndex || k.includes('.')
-          ? `${parentPath || ''}[${value ? k : `"${k}"`}]`
+          ? `${parentPath || ''}[${isIndex ? k : `"${k}"`}]`
           : (parentPath ? `${parentPath}.` : '') + key,
     };
 


### PR DESCRIPTION
Fixes a typo in `asNestedTest()` which is causing #2156