### PR TITLE
Moved the localized object into it's own file

### DIFF
--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,6 +1,7 @@
 import printValue from './util/printValue';
 import { Message } from './types';
 import ValidationError from './ValidationError';
+import en from './locales/en';
 
 export interface MixedLocale {
   default?: Message;
@@ -69,97 +70,4 @@ export interface LocaleObject {
   tuple?: TupleLocale;
 }
 
-export let mixed: Required<MixedLocale> = {
-  default: '${path} is invalid',
-  required: '${path} is a required field',
-  defined: '${path} must be defined',
-  notNull: '${path} cannot be null',
-  oneOf: '${path} must be one of the following values: ${values}',
-  notOneOf: '${path} must not be one of the following values: ${values}',
-  notType: ({ path, type, value, originalValue }) => {
-    const castMsg =
-      originalValue != null && originalValue !== value
-        ? ` (cast from the value \`${printValue(originalValue, true)}\`).`
-        : '.';
-
-    return type !== 'mixed'
-      ? `${path} must be a \`${type}\` type, ` +
-          `but the final value was: \`${printValue(value, true)}\`` +
-          castMsg
-      : `${path} must match the configured type. ` +
-          `The validated value was: \`${printValue(value, true)}\`` +
-          castMsg;
-  },
-};
-
-export let string: Required<StringLocale> = {
-  length: '${path} must be exactly ${length} characters',
-  min: '${path} must be at least ${min} characters',
-  max: '${path} must be at most ${max} characters',
-  matches: '${path} must match the following: "${regex}"',
-  email: '${path} must be a valid email',
-  url: '${path} must be a valid URL',
-  uuid: '${path} must be a valid UUID',
-  trim: '${path} must be a trimmed string',
-  lowercase: '${path} must be a lowercase string',
-  uppercase: '${path} must be a upper case string',
-};
-
-export let number: Required<NumberLocale> = {
-  min: '${path} must be greater than or equal to ${min}',
-  max: '${path} must be less than or equal to ${max}',
-  lessThan: '${path} must be less than ${less}',
-  moreThan: '${path} must be greater than ${more}',
-  positive: '${path} must be a positive number',
-  negative: '${path} must be a negative number',
-  integer: '${path} must be an integer',
-};
-
-export let date: Required<DateLocale> = {
-  min: '${path} field must be later than ${min}',
-  max: '${path} field must be at earlier than ${max}',
-};
-
-export let boolean: BooleanLocale = {
-  isValue: '${path} field must be ${value}',
-};
-
-export let object: Required<ObjectLocale> = {
-  noUnknown: '${path} field has unspecified keys: ${unknown}',
-};
-
-export let array: Required<ArrayLocale> = {
-  min: '${path} field must have at least ${min} items',
-  max: '${path} field must have less than or equal to ${max} items',
-  length: '${path} must have ${length} items',
-};
-
-export let tuple: Required<TupleLocale> = {
-  notType: (params) => {
-    const { path, value, spec } = params;
-    const typeLen = spec.types.length;
-    if (Array.isArray(value)) {
-      if (value.length < typeLen)
-        return `${path} tuple value has too few items, expected a length of ${typeLen} but got ${
-          value.length
-        } for value: \`${printValue(value, true)}\``;
-      if (value.length > typeLen)
-        return `${path} tuple value has too many items, expected a length of ${typeLen} but got ${
-          value.length
-        } for value: \`${printValue(value, true)}\``;
-    }
-
-    return ValidationError.formatError(mixed.notType, params);
-  },
-};
-
-export default Object.assign(Object.create(null), {
-  mixed,
-  string,
-  number,
-  date,
-  object,
-  array,
-  boolean,
-  tuple,
-}) as LocaleObject;
+export default en;

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,6 +1,4 @@
-import printValue from './util/printValue';
 import { Message } from './types';
-import ValidationError from './ValidationError';
 import en from './locales/en';
 
 export interface MixedLocale {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,77 @@
+import type { LocaleObject } from '../locale';
+const en: Required<LocaleObject> = {
+    mixed: {
+        default: '${path} is invalid',
+        required: '${path} is a required field',
+        defined: '${path} must be defined',
+        notNull: '${path} cannot be null',
+        oneOf: '${path} must be one of the following values: ${values}',
+        notOneOf: '${path} must not be one of the following values: ${values}',
+        notType: ({ path, type, value, originalValue }) => {
+            const castMsg =
+                originalValue != null && originalValue !== value
+                    ? ` (cast from the value \`${printValue(originalValue, true)}\`).`
+                    : '.';
+
+            return type !== 'mixed'
+                ? `${path} must be a \`${type}\` type, ` +
+                `but the final value was: \`${printValue(value, true)}\`` +
+                castMsg
+                : `${path} must match the configured type. ` +
+                `The validated value was: \`${printValue(value, true)}\`` +
+                castMsg;
+        }
+    },
+    string: {
+        length: '${path} must be exactly ${length} characters',
+        min: '${path} must be at least ${min} characters',
+        max: '${path} must be at most ${max} characters',
+        matches: '${path} must match the following: "${regex}"',
+        email: '${path} must be a valid email',
+        url: '${path} must be a valid URL',
+        uuid: '${path} must be a valid UUID',
+        trim: '${path} must be a trimmed string',
+        lowercase: '${path} must be a lowercase string',
+        uppercase: '${path} must be a upper case string',
+    },
+    number: {
+        min: '${path} must be greater than or equal to ${min}',
+        max: '${path} must be less than or equal to ${max}',
+        lessThan: '${path} must be less than ${less}',
+        moreThan: '${path} must be greater than ${more}',
+        positive: '${path} must be a positive number',
+        negative: '${path} must be a negative number',
+        integer: '${path} must be an integer',
+    },
+    date: {
+        min: '${path} field must be later than ${min}',
+        max: '${path} field must be at earlier than ${max}',
+    },
+    boolean: {
+        isValue: '${path} field must be ${value}',
+    },
+    object: {
+        noUnknown: '${path} field has unspecified keys: ${unknown}',
+    },
+    array: {
+        min: '${path} field must have at least ${min} items',
+        max: '${path} field must have less than or equal to ${max} items',
+        length: '${path} must have ${length} items',
+    },
+    tuple: {
+        notType: (params) => {
+            const { path, value, spec } = params;
+            const typeLen = spec.types.length;
+            if (Array.isArray(value)) {
+                if (value.length < typeLen)
+                    return `${path} tuple value has too few items, expected a length of ${typeLen} but got ${value.length
+                        } for value: \`${printValue(value, true)}\``;
+                if (value.length > typeLen)
+                    return `${path} tuple value has too many items, expected a length of ${typeLen} but got ${value.length
+                        } for value: \`${printValue(value, true)}\``;
+            }
+
+            return ValidationError.formatError(mixed.notType, params);
+        },
+    }
+};

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,4 +1,22 @@
 import type { LocaleObject } from '../locale';
+import ValidationError from '../ValidationError';
+import printValue from '../util/printValue';
+import { MessageParams } from '../types';
+
+const mixedNotType = ({ path, type, value, originalValue }: MessageParams) => {
+    const castMsg =
+        originalValue != null && originalValue !== value
+            ? ` (cast from the value \`${printValue(originalValue, true)}\`).`
+            : '.';
+
+    return type !== 'mixed'
+        ? `${path} must be a \`${type}\` type, ` +
+        `but the final value was: \`${printValue(value, true)}\`` +
+        castMsg
+        : `${path} must match the configured type. ` +
+        `The validated value was: \`${printValue(value, true)}\`` +
+        castMsg;
+};
 const en: Required<LocaleObject> = {
     mixed: {
         default: '${path} is invalid',
@@ -7,20 +25,7 @@ const en: Required<LocaleObject> = {
         notNull: '${path} cannot be null',
         oneOf: '${path} must be one of the following values: ${values}',
         notOneOf: '${path} must not be one of the following values: ${values}',
-        notType: ({ path, type, value, originalValue }) => {
-            const castMsg =
-                originalValue != null && originalValue !== value
-                    ? ` (cast from the value \`${printValue(originalValue, true)}\`).`
-                    : '.';
-
-            return type !== 'mixed'
-                ? `${path} must be a \`${type}\` type, ` +
-                `but the final value was: \`${printValue(value, true)}\`` +
-                castMsg
-                : `${path} must match the configured type. ` +
-                `The validated value was: \`${printValue(value, true)}\`` +
-                castMsg;
-        }
+        notType: mixedNotType
     },
     string: {
         length: '${path} must be exactly ${length} characters',
@@ -71,7 +76,9 @@ const en: Required<LocaleObject> = {
                         } for value: \`${printValue(value, true)}\``;
             }
 
-            return ValidationError.formatError(mixed.notType, params);
+            return ValidationError.formatError(mixedNotType, params);
         },
     }
 };
+
+export default en;


### PR DESCRIPTION
This will provide a example for i18n to translate as it is a single object that needs to be manipulated and separated from the type definition.

In addition the `as` was removed as it type coercion rather than a type check