### PR TITLE
Add isValid and isValidSync to ISchema interface

### DIFF
--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -136,7 +136,7 @@ class Lazy<T, TContext = AnyObject, TFlags extends Flags = any>
     return this._resolve(value, options).isValid(value, options);
   }
 
-  isValidSync(value: any, options?: ValidateOptions<TContext>) {
+  isValidSync(value: any, options?: ValidateOptions<TContext>): value is this['__outputType']  {
     return this._resolve(value, options).isValidSync(value, options);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface ISchema<T, C = any, F extends Flags = any, D = any> {
   cast(value: any, options: CastOptionalityOptions<C>): T | null | undefined;
 
   validate(value: any, options?: ValidateOptions<C>): Promise<T>;
+  isValid(value: any, options?: ValidateOptions<C>): Promise<boolean>;
+  isValidSync(value: any, options?: ValidateOptions<C>): value is T;
 
   asNestedTest(config: NestedTestConfig): Test;
 


### PR DESCRIPTION
Addresses #2182. Makes `isValid` and `isValidSync` available from an `ISchema`. 

- Add isValid and isValidSync to ISchema interface
- Updates Lazy.isValidSync definition to serve as a type guard
- Mainly type changes, but no breaking changes. No behavioral changes, so I don't see a good place to update unit tests.