### PR TITLE
Fix readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const parsedUser = await userSchema.validate(
 - [Error message customization](#error-message-customization)
   - [localization and i18n](#localization-and-i18n)
 - [API](#api)
-  - [`yup`](#yup)
+  - [`yup`](#yup-1)
     - [`reach(schema: Schema, path: string, value?: object, context?: object): Schema`](#reachschema-schema-path-string-value-object-context-object-schema)
     - [`addMethod(schemaType: Schema, name: string, method: ()=> Schema): void`](#addmethodschematype-schema-name-string-method--schema-void)
     - [`ref(path: string, options: { contextPrefix: string }): Ref`](#refpath-string-options--contextprefix-string--ref)


### PR DESCRIPTION
# Update Duplicate Section Anchors in README

## Overview
This PR aims to improve navigation within the README document by updating the anchor links for duplicate section titles. Specifically, it addresses the issue where multiple sections titled `yup` have been assigned identical anchor links, making it difficult to link to them individually.

## Changes Made
- Updated the anchor link for the second occurrence of the `yup` section to ensure it is unique and navigable. The original link `#yup` remains unchanged for the first section, while the second section's link has been updated to `#yup-1`.

## Reasoning
In Markdown documents, especially in GitHub-flavored Markdown, duplicate headings result in automatically generated, incremented anchor links (e.g., `#yup`, `#yup-1`, etc.) to maintain uniqueness. However, when manually linking to these sections within the same document, it's essential to use the correct, unique anchor link to ensure the reader is directed to the intended section.

By making this change, we aim to:
- Improve the readability and navigability of the README.
- Ensure that links within the document are accurate and lead to the correct sections, enhancing the overall user experience.

## Example
Here is how the updated links would be used in practice:

- Link to the first `yup` section: [`yup`](#yup)
- Link to the second `yup` section: [`yup`](#yup-1)

Thank you for considering this improvement to the README documentation. I believe these changes will make it easier for readers to navigate the document and find the information they need efficiently.

