### PR TITLE
Fixed logic in "42" tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,7 +779,7 @@ For instance this will work:
 let schema = number().test(
   'is-42',
   "this isn't the number i want",
-  (value) => value != 42,
+  (value) => value === 42,
 );
 
 schema.validateSync(23); // throws ValidationError
@@ -789,7 +789,7 @@ however this will not:
 
 ```js
 let schema = number().test('is-42', "this isn't the number i want", (value) =>
-  Promise.resolve(value != 42),
+  Promise.resolve(value === 42),
 );
 
 schema.validateSync(42); // throws Error


### PR DESCRIPTION
The logic in the "42" tests was backwards. It was checking that the number didn't equal 42, when it should check the number does equal 42.