### PR TITLE
fix(regex): update the email regex for more cases

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -19,7 +19,7 @@ import { parseDateStruct } from './util/parseIsoDate';
 // Taken from HTML spec: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
 let rEmail =
   // eslint-disable-next-line
-  /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+  /^(([^<>()[]\.,;:\s@"]+(.[^<>()[]\.,;:\s@"]+)*)|.(".+"))@(([[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}])|(([a-zA-Z-0-9]+.)+[a-zA-Z]{2,}))$/;
 
 let rUrl =
   // eslint-disable-next-line


### PR DESCRIPTION
The yup.string().email() works via regex but is does not cover cases like:

- test-user@abccom
- test-user@abc.com
- test.user.@abc.com
- test..user@abc.com
- test.user@abc–88.com
- test.user@abc.r
- 0@g.q

This PR resolves this issue.
    
    