### PR TITLE
feat(meta): add meta() data with function

### DIFF
--- a/test/lazy.ts
+++ b/test/lazy.ts
@@ -54,5 +54,29 @@ describe('lazy', function () {
         added: true,
       });
     });
+
+    it('should add meta() data', () => {
+      const schema = lazy(mapper);
+
+      expect(schema.meta({ input: 'foo' }).meta({ foo: 'bar' }).meta()).toEqual(
+        {
+          input: 'foo',
+          foo: 'bar',
+        },
+      );
+    });
+
+    it('should add meta() data with function', () => {
+      const schema = lazy(mapper);
+
+      expect(
+        schema
+          .meta({ list: ['foo'] })
+          .meta((prev: any) => ({ list: [...prev.list, 'bar'] }))
+          .meta(),
+      ).toEqual({
+        list: ['foo', 'bar'],
+      });
+    });
   });
 });

--- a/test/mixed.ts
+++ b/test/mixed.ts
@@ -959,6 +959,17 @@ describe('Mixed Types ', () => {
     );
   });
 
+  it('should add meta() data with function', () => {
+    expect(
+      string()
+        .meta({ list: ['foo'] })
+        .meta((prev) => ({ list: [...prev.list, 'bar'] }))
+        .meta(),
+    ).toEqual({
+      list: ['foo', 'bar'],
+    });
+  });
+
   describe('schema.describe()', () => {
     let schema: ObjectSchema<any>;
     beforeEach(() => {


### PR DESCRIPTION
Enabled passing functions with `yup.meta(prev => ({...}))`. 

Array metadata can be merged!