### PR TITLE
Enhance NumberSchema to reject internal whitespace while allowing leading/trailing spaces

### DIFF
--- a/src/number.ts
+++ b/src/number.ts
@@ -47,9 +47,10 @@ export default class NumberSchema<
 
         let parsed = value;
         if (typeof parsed === 'string') {
-          parsed = parsed.replace(/\s/g, '');
-          if (parsed === '') return NaN;
-          // don't use parseFloat to avoid positives on alpha-numeric strings
+          //Trim leading and trailing whitespace
+          parsed = parsed.trim();
+          //Only allow strings that consist of digits, possibly with a single decimal point
+          if (!/^\d+(\.\d+)?$/.test(parsed)) return NaN;
           parsed = +parsed;
         }
 


### PR DESCRIPTION
## Description

This PR modifies the NumberSchema to enhance number validation, addressing an issue where strings with internal whitespace (e.g., "9 9") were incorrectly passing validation.

### Changes:

1. Updated the `transform` function in the NumberSchema constructor to:
   - Trim leading and trailing whitespace from string inputs
   - Use a regular expression to strictly validate the number format
   - Reject strings with internal whitespace or non-numeric characters

### Behavior changes:

- "99 " and " 99" now pass validation (trimmed to 99)
- "9 9" now fails validation (becomes NaN)
- "9.9" continues to pass validation (becomes 9.9)
- "9,9" now fails validation (becomes NaN)

### Implementation details:

```javascript
parsed = parsed.trim();
if (!/^\d+(\.\d+)?$/.test(parsed)) return NaN;