### PR TITLE
Export locale object interfaces to improve setLocale typescript support for added methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,16 @@ import reach, { getIn } from './util/reach';
 import isSchema from './util/isSchema';
 import printValue from './util/printValue';
 import setLocale, { LocaleObject } from './setLocale';
-import defaultLocale from './locale';
+import defaultLocale, {
+  MixedLocale,
+  StringLocale,
+  NumberLocale,
+  DateLocale,
+  ObjectLocale,
+  ArrayLocale,
+  TupleLocale,
+  BooleanLocale,
+} from './locale';
 import Schema, {
   AnySchema,
   CastOptions as BaseCastOptions,
@@ -82,6 +91,14 @@ export type {
   SchemaMetadata,
   CustomSchemaMetadata,
   LocaleObject,
+  MixedLocale,
+  StringLocale,
+  NumberLocale,
+  DateLocale,
+  ObjectLocale,
+  ArrayLocale,
+  TupleLocale,
+  BooleanLocale,
   ValidateOptions,
   DefaultThunk,
   Lazy,


### PR DESCRIPTION
Added exporting of locale interfaces (MixedLocale, StringLocale, NumberLocale,DateLocale,ObjectLocale, ArrayLocale, TupleLocale and BooleanLocale) to enable extending them when adding new methods.

More details in issue:
https://github.com/jquense/yup/issues/2248