### PR TITLE
Fix `ValidationError.formatError()` clobbering `path` param

### DIFF
--- a/src/ValidationError.ts
+++ b/src/ValidationError.ts
@@ -63,8 +63,11 @@ export default class ValidationError extends Error {
     message: string | ((params: Params) => string) | unknown,
     params: Params,
   ) {
+    // Attempt to make the path more friendly for error message interpolation.
     const path = params.label || params.path || 'this';
-    if (path !== params.path) params = { ...params, path };
+    // Store the original path under `originalPath` so it isn't lost to custom
+    // message functions; e.g., ones provided in `setLocale()` calls.
+    params = { ...params, path, originalPath: params.path };
 
     if (typeof message === 'string')
       return message.replace(strReg, (_, key) => printValue(params[key]));

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,11 @@ import Schema, {
   CustomSchemaMetadata,
 } from './schema';
 import type {
+  AnyMessageParams,
   InferType,
   ISchema,
   Message,
+  MessageParams,
   ValidateOptions,
   DefaultThunk,
 } from './types';
@@ -65,11 +67,13 @@ export type AnyObjectSchema = ObjectSchema<any, any, any, any>;
 export type CastOptions = Omit<BaseCastOptions, 'path' | 'resolved'>;
 
 export type {
+  AnyMessageParams,
   AnyObject,
   InferType,
   InferType as Asserts,
   ISchema,
   Message,
+  MessageParams,
   AnySchema,
   MixedOptions,
   TypeGuard as MixedTypeGuard,

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface MessageParams {
   path: string;
   value: any;
   originalValue: any;
+  originalPath: string;
   label: string;
   type: string;
   spec: SchemaSpec<any> & Record<string, unknown>;


### PR DESCRIPTION
## Changes
- `ValidationError.formatError()` overwrites `path` with a more friendly `label` string (if defined) for more friendly error message interpolation; however, this causes the `path` data to be lost entirely.
  - Rather than undertake refactoring this logic and cause a breaking change, where using alternative values for interpolating `${path}` within error strings should arguably be a concern that's left to the `message` function, I opted to simply create a new `params` property—`originalPath`—for recording this value.
- Update `MessageParams` type with `originalPath: string;` property
- Add `MessageParams` and `AnyMessageParams` to library exports
  - I couldn't see a reason why these types are private, and I'd certainly love to make use of them.