### PR TITLE
feat: Implement standard schema interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Yup is a schema builder for runtime value parsing and validation. Define a schem
 - Built-in async validation support. Model server-side and client-side validation equally well
 - Extensible: add your own type-safe methods and schema
 - Rich error details, make debugging a breeze
+- Compatible with [Standard Schema](https://github.com/standard-schema/standard-schema)
 
 ## Getting Started
 
@@ -470,6 +471,10 @@ try {
   messages = err.errors.map((err) => i18next.t(err.key));
 }
 ```
+
+## Standard Schema Support
+
+Yup is compatible with [Standard Schema](https://github.com/standard-schema/standard-schema).
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@standard-schema/spec": "^1.0.0-beta.3",
+    "@standard-schema/spec": "^1.0.0-beta.4",
     "@types/jest": "^27.5.2",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@standard-schema/spec": "^1.0.0-beta.4",
+    "@standard-schema/spec": "^1.0.0-rc.0",
     "@types/jest": "^27.5.2",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
+    "@standard-schema/spec": "^1.0.0-beta.3",
     "@types/jest": "^27.5.2",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/preset-typescript": "^7.22.5",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "@standard-schema/spec": "^1.0.0-rc.0",
+    "@standard-schema/spec": "^1.0.0",
     "@types/jest": "^27.5.2",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -34,6 +34,11 @@ import isAbsent from './util/isAbsent';
 import type { Flags, Maybe, ResolveFlags, _ } from './util/types';
 import toArray from './util/toArray';
 import cloneDeep from './util/cloneDeep';
+import {
+  createStandardSchemaProps,
+  type StandardSchema,
+  type StandardSchemaProps,
+} from './standardSchema';
 
 export type SchemaSpec<TDefault> = {
   coerce: boolean;
@@ -148,7 +153,9 @@ export default abstract class Schema<
   TContext = any,
   TDefault = any,
   TFlags extends Flags = '',
-> implements ISchema<TType, TContext, TFlags, TDefault>
+> implements
+    ISchema<TType, TContext, TFlags, TDefault>,
+    StandardSchema<TType, ResolveFlags<TType, TFlags, TDefault>>
 {
   readonly type: string;
 
@@ -174,6 +181,11 @@ export default abstract class Schema<
 
   protected exclusiveTests: Record<string, boolean> = Object.create(null);
   protected _typeCheck: (value: any) => value is NonNullable<TType>;
+
+  public '~standard': StandardSchemaProps<
+    TType,
+    ResolveFlags<TType, TFlags, TDefault>
+  >;
 
   spec: SchemaSpec<any>;
 
@@ -203,6 +215,11 @@ export default abstract class Schema<
     this.withMutation((s) => {
       s.nonNullable();
     });
+
+    this['~standard'] = createStandardSchemaProps<
+      TType,
+      ResolveFlags<TType, TFlags, TDefault>
+    >(this);
   }
 
   // TODO: remove

--- a/src/standardSchema.ts
+++ b/src/standardSchema.ts
@@ -1,0 +1,100 @@
+/**
+ * Copied from @standard-schema/spec to avoid having a dependency on it.
+ * https://github.com/standard-schema/standard-schema/blob/main/packages/spec/src/index.ts
+ */
+
+import type { AnySchema } from './types';
+import ValidationError from './ValidationError';
+
+export interface StandardSchema<Input = unknown, Output = Input> {
+  readonly '~standard': StandardSchemaProps<Input, Output>;
+}
+
+export interface StandardSchemaProps<Input = unknown, Output = Input> {
+  readonly version: 1;
+  readonly vendor: string;
+  readonly validate: (
+    value: unknown,
+  ) => StandardResult<Output> | Promise<StandardResult<Output>>;
+  readonly types?: StandardTypes<Input, Output> | undefined;
+}
+
+type StandardResult<Output> =
+  | StandardSuccessResult<Output>
+  | StandardFailureResult;
+
+interface StandardSuccessResult<Output> {
+  readonly value: Output;
+  readonly issues?: undefined;
+}
+
+interface StandardFailureResult {
+  readonly issues: ReadonlyArray<StandardIssue>;
+}
+
+interface StandardIssue {
+  readonly message: string;
+  readonly path?: ReadonlyArray<PropertyKey | StandardPathSegment> | undefined;
+}
+
+interface StandardPathSegment {
+  readonly key: PropertyKey;
+}
+
+interface StandardTypes<Input, Output> {
+  readonly input: Input;
+  readonly output: Output;
+}
+
+export function createStandardSchemaProps<TIn, Output>(
+  schema: AnySchema,
+): StandardSchemaProps<TIn, Output> {
+  /**
+   * Adapts the schema's validate method to the standard schema's validate method.
+   */
+  async function validate(value: unknown): Promise<StandardResult<Output>> {
+    try {
+      const result = await schema.validate(value);
+
+      return {
+        value: result as Output,
+      };
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        return {
+          issues: issuesFromValidationError(err),
+        };
+      }
+
+      throw err;
+    }
+  }
+
+  return {
+    version: 1,
+    vendor: 'yup',
+    validate,
+  };
+}
+
+function createStandardPath(path: string | undefined) {
+  return path?.split('.').map((key) => ({ key })) ?? [];
+}
+
+function createStandardIssues(error: ValidationError): StandardIssue[] {
+  return error.errors.map(
+    (err) =>
+      ({
+        message: err,
+        path: createStandardPath(error.path),
+      } satisfies StandardIssue),
+  );
+}
+
+function issuesFromValidationError(error: ValidationError): StandardIssue[] {
+  if (!error.inner?.length && error.errors.length) {
+    return createStandardIssues(error);
+  }
+
+  return error.inner.flatMap(issuesFromValidationError);
+}

--- a/src/standardSchema.ts
+++ b/src/standardSchema.ts
@@ -3,7 +3,6 @@
  * https://github.com/standard-schema/standard-schema/blob/main/packages/spec/src/index.ts
  */
 
-import type { AnySchema } from './types';
 import ValidationError from './ValidationError';
 
 export interface StandardSchema<Input = unknown, Output = Input> {
@@ -19,67 +18,36 @@ export interface StandardSchemaProps<Input = unknown, Output = Input> {
   readonly types?: StandardTypes<Input, Output> | undefined;
 }
 
-type StandardResult<Output> =
+export type StandardResult<Output> =
   | StandardSuccessResult<Output>
   | StandardFailureResult;
 
-interface StandardSuccessResult<Output> {
+export interface StandardSuccessResult<Output> {
   readonly value: Output;
   readonly issues?: undefined;
 }
 
-interface StandardFailureResult {
+export interface StandardFailureResult {
   readonly issues: ReadonlyArray<StandardIssue>;
 }
 
-interface StandardIssue {
+export interface StandardIssue {
   readonly message: string;
   readonly path?: ReadonlyArray<PropertyKey | StandardPathSegment> | undefined;
 }
 
-interface StandardPathSegment {
+export interface StandardPathSegment {
   readonly key: PropertyKey;
 }
 
-interface StandardTypes<Input, Output> {
+export interface StandardTypes<Input, Output> {
   readonly input: Input;
   readonly output: Output;
 }
 
-export function createStandardSchemaProps<TIn, Output>(
-  schema: AnySchema,
-): StandardSchemaProps<TIn, Output> {
-  /**
-   * Adapts the schema's validate method to the standard schema's validate method.
-   */
-  async function validate(value: unknown): Promise<StandardResult<Output>> {
-    try {
-      const result = await schema.validate(value, {
-        abortEarly: false,
-      });
-
-      return {
-        value: result as Output,
-      };
-    } catch (err) {
-      if (err instanceof ValidationError) {
-        return {
-          issues: issuesFromValidationError(err),
-        };
-      }
-
-      throw err;
-    }
-  }
-
-  return {
-    version: 1,
-    vendor: 'yup',
-    validate,
-  };
-}
-
-function createStandardPath(path: string | undefined): StandardIssue['path'] {
+export function createStandardPath(
+  path: string | undefined,
+): StandardIssue['path'] {
   if (!path?.length) {
     return undefined;
   }
@@ -147,7 +115,7 @@ function createStandardPath(path: string | undefined): StandardIssue['path'] {
   return segments;
 }
 
-function createStandardIssues(
+export function createStandardIssues(
   error: ValidationError,
   parentPath?: string,
 ): StandardIssue[] {
@@ -162,7 +130,7 @@ function createStandardIssues(
   );
 }
 
-function issuesFromValidationError(
+export function issuesFromValidationError(
   error: ValidationError,
   parentPath?: string,
 ): StandardIssue[] {

--- a/src/standardSchema.ts
+++ b/src/standardSchema.ts
@@ -151,13 +151,13 @@ function createStandardIssues(
   error: ValidationError,
   parentPath?: string,
 ): StandardIssue[] {
+  const path = parentPath ? `${parentPath}.${error.path}` : error.path;
+
   return error.errors.map(
     (err) =>
       ({
         message: err,
-        path: createStandardPath(
-          parentPath ? `${parentPath}.${error.path}` : error.path,
-        ),
+        path: createStandardPath(path),
       } satisfies StandardIssue),
   );
 }
@@ -170,10 +170,7 @@ function issuesFromValidationError(
     return createStandardIssues(error, parentPath);
   }
 
-  return error.inner.flatMap((err) =>
-    issuesFromValidationError(
-      err,
-      parentPath ? `${parentPath}.${error.path}` : error.path,
-    ),
-  );
+  const path = parentPath ? `${parentPath}.${error.path}` : error.path;
+
+  return error.inner.flatMap((err) => issuesFromValidationError(err, path));
 }

--- a/test/standardSchema.ts
+++ b/test/standardSchema.ts
@@ -30,3 +30,38 @@ test('is compatible with standard schema', () => {
   expect(verifyStandardSchema(mixed())).toBe(true);
   expect(verifyStandardSchema(tuple([mixed()]))).toBe(true);
 });
+
+test('issues path is an array of property paths', async () => {
+  const schema = object({
+    obj: object({
+      foo: string().required(),
+      'not.obj.nested': string().required(),
+    }).required(),
+    arr: array(
+      object({
+        foo: string().required(),
+        'not.array.nested': string().required(),
+      }),
+    ).required(),
+    'not.a.field': string().required(),
+  });
+
+  const result = await schema['~standard'].validate({
+    obj: { foo: '', 'not.obj.nested': '' },
+    arr: [{ foo: '', 'not.array.nested': '' }],
+  });
+
+  expect(result.issues).toEqual([
+    { path: ['obj', 'foo'], message: 'obj.foo is a required field' },
+    {
+      path: ['obj', 'not.obj.nested'],
+      message: 'obj["not.obj.nested"] is a required field',
+    },
+    { path: ['arr', '0', 'foo'], message: 'arr[0].foo is a required field' },
+    {
+      path: ['arr', '0', 'not.array.nested'],
+      message: 'arr[0]["not.array.nested"] is a required field',
+    },
+    { path: ['not.a.field'], message: '["not.a.field"] is a required field' },
+  ]);
+});

--- a/test/standardSchema.ts
+++ b/test/standardSchema.ts
@@ -7,6 +7,7 @@ import {
   date,
   mixed,
   tuple,
+  lazy,
 } from '../src';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 
@@ -29,6 +30,7 @@ test('is compatible with standard schema', () => {
   expect(verifyStandardSchema(date())).toBe(true);
   expect(verifyStandardSchema(mixed())).toBe(true);
   expect(verifyStandardSchema(tuple([mixed()]))).toBe(true);
+  expect(verifyStandardSchema(lazy(() => string()))).toBe(true);
 });
 
 test('issues path is an array of property paths', async () => {

--- a/test/standardSchema.ts
+++ b/test/standardSchema.ts
@@ -8,10 +8,10 @@ import {
   mixed,
   tuple,
 } from '../src';
-import type { v1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 function verifyStandardSchema<Input, Output>(
-  schema: v1.StandardSchema<Input, Output>,
+  schema: StandardSchemaV1<Input, Output>,
 ) {
   return (
     schema['~standard'].version === 1 &&

--- a/test/standardSchema.ts
+++ b/test/standardSchema.ts
@@ -1,0 +1,32 @@
+import {
+  string,
+  number,
+  array,
+  bool,
+  object,
+  date,
+  mixed,
+  tuple,
+} from '../src';
+import type { v1 } from '@standard-schema/spec';
+
+function verifyStandardSchema<Input, Output>(
+  schema: v1.StandardSchema<Input, Output>,
+) {
+  return (
+    schema['~standard'].version === 1 &&
+    schema['~standard'].vendor === 'yup' &&
+    typeof schema['~standard'].validate === 'function'
+  );
+}
+
+test('is compatible with standard schema', () => {
+  expect(verifyStandardSchema(string())).toBe(true);
+  expect(verifyStandardSchema(number())).toBe(true);
+  expect(verifyStandardSchema(array())).toBe(true);
+  expect(verifyStandardSchema(bool())).toBe(true);
+  expect(verifyStandardSchema(object())).toBe(true);
+  expect(verifyStandardSchema(date())).toBe(true);
+  expect(verifyStandardSchema(mixed())).toBe(true);
+  expect(verifyStandardSchema(tuple([mixed()]))).toBe(true);
+});

--- a/test/standardSchema.ts
+++ b/test/standardSchema.ts
@@ -103,3 +103,527 @@ test('should work correctly with lazy schemas', async () => {
     { path: undefined, message: 'this must be greater than or equal to 10' },
   ]);
 });
+
+describe('Array schema standard interface tests', () => {
+  test('should handle basic array validation', async () => {
+    const schema = array(string());
+
+    // Test with valid array
+    const validResult = await schema['~standard'].validate(['a', 'b', 'c']);
+    if (!validResult.issues) {
+      expect(validResult.value).toEqual(['a', 'b', 'c']);
+    }
+
+    // Test with invalid array items - use an object that can't be cast to string
+    const invalidResult = await schema['~standard'].validate([
+      'a',
+      { foo: 'bar' },
+      'c',
+    ]);
+    expect(invalidResult.issues).toBeDefined();
+    expect(invalidResult.issues?.[0]?.path).toEqual(['1']);
+    expect(invalidResult.issues?.[0]?.message).toContain(
+      'must be a `string` type',
+    );
+  });
+
+  test('should handle array length validations', async () => {
+    const schema = array(string()).min(2).max(4);
+
+    // Test empty array
+    const emptyResult = await schema['~standard'].validate([]);
+    expect(emptyResult.issues).toEqual([
+      { path: undefined, message: 'this field must have at least 2 items' },
+    ]);
+
+    // Test array too long
+    const longResult = await schema['~standard'].validate([
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+    ]);
+    expect(longResult.issues).toEqual([
+      {
+        path: undefined,
+        message: 'this field must have less than or equal to 4 items',
+      },
+    ]);
+  });
+
+  test('should handle required array validation', async () => {
+    const schema = array(string()).required();
+
+    const result = await schema['~standard'].validate(undefined);
+    expect(result.issues).toEqual([
+      { path: undefined, message: 'this is a required field' },
+    ]);
+  });
+
+  test('array validation should produce same errors as main API', async () => {
+    const schema = array(string().required()).min(2);
+    const testValue = ['valid', ''];
+
+    // Test with standard schema
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    // Test with main API
+    let mainAPIError: any;
+    try {
+      await schema.validate(testValue, { abortEarly: false });
+    } catch (err) {
+      mainAPIError = err;
+    }
+
+    // Compare error messages
+    expect(standardResult.issues).toBeDefined();
+    expect(mainAPIError).toBeDefined();
+    expect(standardResult.issues?.length).toBe(mainAPIError.inner.length);
+
+    const standardMessages = standardResult.issues
+      ?.map((issue) => issue.message)
+      .sort();
+    const mainMessages = mainAPIError.inner
+      .map((err: any) => err.message)
+      .sort();
+    expect(standardMessages).toEqual(mainMessages);
+  });
+});
+
+describe('Object schema standard interface tests', () => {
+  test('should handle basic object validation', async () => {
+    const schema = object({
+      name: string().required(),
+      age: number().required().min(0),
+    });
+
+    // Test with valid object
+    const validResult = await schema['~standard'].validate({
+      name: 'John',
+      age: 25,
+    });
+    if (!validResult.issues) {
+      expect(validResult.value).toEqual({ name: 'John', age: 25 });
+    }
+
+    // Test with invalid object
+    const invalidResult = await schema['~standard'].validate({
+      name: '',
+      age: -1,
+    });
+    expect(invalidResult.issues).toBeDefined();
+    expect(invalidResult.issues).toEqual(
+      expect.arrayContaining([
+        { path: ['name'], message: 'name is a required field' },
+        { path: ['age'], message: 'age must be greater than or equal to 0' },
+      ]),
+    );
+  });
+
+  test('should handle nested object validation', async () => {
+    const schema = object({
+      user: object({
+        profile: object({
+          name: string().required(),
+          email: string().email(),
+        }),
+      }),
+    });
+
+    const invalidResult = await schema['~standard'].validate({
+      user: {
+        profile: {
+          name: '',
+          email: 'invalid-email',
+        },
+      },
+    });
+
+    expect(invalidResult.issues).toBeDefined();
+    expect(invalidResult.issues).toEqual(
+      expect.arrayContaining([
+        {
+          path: ['user', 'profile', 'name'],
+          message: 'user.profile.name is a required field',
+        },
+        {
+          path: ['user', 'profile', 'email'],
+          message: 'user.profile.email must be a valid email',
+        },
+      ]),
+    );
+  });
+
+  test('should handle object with array fields', async () => {
+    const schema = object({
+      tags: array(string().required()).min(1),
+      metadata: object({
+        version: number().required(),
+      }).required(),
+    });
+
+    const invalidResult = await schema['~standard'].validate({
+      tags: [],
+      metadata: null,
+    });
+
+    expect(invalidResult.issues).toBeDefined();
+    expect(invalidResult.issues).toEqual(
+      expect.arrayContaining([
+        { path: ['tags'], message: 'tags field must have at least 1 items' },
+        { path: ['metadata'], message: 'metadata is a required field' },
+      ]),
+    );
+  });
+
+  test('object validation should produce same errors as main API', async () => {
+    const schema = object({
+      email: string().email().required(),
+      age: number().min(18).required(),
+      profile: object({
+        bio: string().max(100),
+      }),
+    });
+
+    const testValue = {
+      email: 'invalid-email',
+      age: 16,
+      profile: {
+        bio: 'x'.repeat(150),
+      },
+    };
+
+    // Test with standard schema
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    // Test with main API
+    let mainAPIError: any;
+    try {
+      await schema.validate(testValue, { abortEarly: false });
+    } catch (err) {
+      mainAPIError = err;
+    }
+
+    // Compare error messages
+    expect(standardResult.issues).toBeDefined();
+    expect(mainAPIError).toBeDefined();
+    expect(standardResult.issues?.length).toBe(mainAPIError.inner.length);
+
+    const standardMessages = standardResult.issues
+      ?.map((issue) => issue.message)
+      .sort();
+    const mainMessages = mainAPIError.inner
+      .map((err: any) => err.message)
+      .sort();
+    expect(standardMessages).toEqual(mainMessages);
+  });
+});
+
+describe('Lazy schema standard interface tests', () => {
+  test('should handle conditional lazy schema validation', async () => {
+    const schema = lazy((value: any) => {
+      if (typeof value === 'string') {
+        return string().min(5);
+      }
+      if (typeof value === 'number') {
+        return number().max(100);
+      }
+      return mixed().required();
+    });
+
+    // Test string validation
+    const stringResult = await schema['~standard'].validate('abc');
+    expect(stringResult.issues).toEqual([
+      { path: undefined, message: 'this must be at least 5 characters' },
+    ]);
+
+    // Test number validation
+    const numberResult = await schema['~standard'].validate(150);
+    expect(numberResult.issues).toEqual([
+      { path: undefined, message: 'this must be less than or equal to 100' },
+    ]);
+
+    // Test successful validation
+    const validStringResult = await schema['~standard'].validate('hello world');
+    if (!validStringResult.issues) {
+      expect(validStringResult.value).toBe('hello world');
+    }
+  });
+
+  test('should handle lazy schema with object validation', async () => {
+    const schema = lazy((value: any) => {
+      if (value?.type === 'user') {
+        return object({
+          type: string().oneOf(['user']),
+          name: string().required(),
+          email: string().email().required(),
+        });
+      }
+      if (value?.type === 'admin') {
+        return object({
+          type: string().oneOf(['admin']),
+          name: string().required(),
+          permissions: array(string()).min(1),
+        });
+      }
+      return object({
+        type: string().required(),
+      });
+    });
+
+    // Test user validation
+    const userResult = await schema['~standard'].validate({
+      type: 'user',
+      name: '',
+      email: 'invalid',
+    });
+
+    expect(userResult.issues).toBeDefined();
+    expect(userResult.issues).toEqual(
+      expect.arrayContaining([
+        { path: ['name'], message: 'name is a required field' },
+        { path: ['email'], message: 'email must be a valid email' },
+      ]),
+    );
+
+    // Test admin validation
+    const adminResult = await schema['~standard'].validate({
+      type: 'admin',
+      name: 'Admin User',
+      permissions: [],
+    });
+
+    expect(adminResult.issues).toEqual([
+      {
+        path: ['permissions'],
+        message: 'permissions field must have at least 1 items',
+      },
+    ]);
+  });
+
+  test('lazy validation should produce same errors as main API', async () => {
+    const schema = lazy((value: any) => {
+      if (Array.isArray(value)) {
+        return array(string().required()).min(2);
+      }
+      return string().required().min(5);
+    });
+
+    const testValue = ['valid', ''];
+
+    // Test with standard schema
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    // Test with main API
+    let mainAPIError: any;
+    try {
+      await schema.validate(testValue, { abortEarly: false });
+    } catch (err) {
+      mainAPIError = err;
+    }
+
+    // Compare error messages
+    expect(standardResult.issues).toBeDefined();
+    expect(mainAPIError).toBeDefined();
+    expect(standardResult.issues?.length).toBe(mainAPIError.inner.length);
+
+    const standardMessages = standardResult.issues
+      ?.map((issue) => issue.message)
+      .sort();
+    const mainMessages = mainAPIError.inner
+      .map((err: any) => err.message)
+      .sort();
+    expect(standardMessages).toEqual(mainMessages);
+  });
+});
+
+describe('Complex nested validation comparisons', () => {
+  test('should handle deeply nested structure validation identically', async () => {
+    const schema = object({
+      users: array(
+        object({
+          id: number().required().positive(),
+          profile: object({
+            name: string().required().min(2),
+            contact: object({
+              email: string().email().required(),
+              phone: string().matches(/^\d{10}$/, 'Phone must be 10 digits'),
+            }),
+          }),
+          preferences: array(string()).max(5),
+        }),
+      ).min(1),
+      metadata: object({
+        version: string().required(),
+        tags: array(string().required()).min(1),
+      }),
+    });
+
+    const testValue = {
+      users: [
+        {
+          id: -1,
+          profile: {
+            name: 'A',
+            contact: {
+              email: 'invalid-email',
+              phone: '123',
+            },
+          },
+          preferences: ['a', 'b', 'c', 'd', 'e', 'f'],
+        },
+      ],
+      metadata: {
+        version: '',
+        tags: [],
+      },
+    };
+
+    // Test with standard schema
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    // Test with main API
+    let mainAPIError: any;
+    try {
+      await schema.validate(testValue, { abortEarly: false });
+    } catch (err) {
+      mainAPIError = err;
+    }
+
+    // Both should have errors
+    expect(standardResult.issues).toBeDefined();
+    expect(mainAPIError).toBeDefined();
+
+    // Compare error counts
+    expect(standardResult.issues?.length).toBe(mainAPIError.inner.length);
+
+    // Compare error messages (order might differ, so sort them)
+    const standardMessages = standardResult.issues
+      ?.map((issue) => issue.message)
+      .sort();
+    const mainMessages = mainAPIError.inner
+      .map((err: any) => err.message)
+      .sort();
+    expect(standardMessages).toEqual(mainMessages);
+
+    // Verify specific error paths exist
+    const standardPaths = standardResult.issues?.map((issue) =>
+      issue.path ? issue.path.join('.') : undefined,
+    );
+    expect(standardPaths).toContain('users.0.id');
+    expect(standardPaths).toContain('users.0.profile.name');
+    expect(standardPaths).toContain('users.0.profile.contact.email');
+    expect(standardPaths).toContain('users.0.profile.contact.phone');
+    expect(standardPaths).toContain('users.0.preferences');
+    expect(standardPaths).toContain('metadata.version');
+    expect(standardPaths).toContain('metadata.tags');
+  });
+
+  test('should handle successful validation identically', async () => {
+    const schema = object({
+      name: string().required(),
+      age: number().min(0).max(120),
+      email: string().email(),
+      address: object({
+        street: string(),
+        city: string().required(),
+        zipCode: string().matches(/^\d{5}$/),
+      }),
+      hobbies: array(string()).max(10),
+    });
+
+    const validValue = {
+      name: 'John Doe',
+      age: 30,
+      email: 'john@example.com',
+      address: {
+        street: '123 Main St',
+        city: 'Anytown',
+        zipCode: '12345',
+      },
+      hobbies: ['reading', 'swimming'],
+    };
+
+    // Test with standard schema
+    const standardResult = await schema['~standard'].validate(validValue);
+
+    // Test with main API
+    const mainResult = await schema.validate(validValue);
+
+    // Both should succeed
+    expect(standardResult.issues).toBeUndefined();
+    if (!standardResult.issues) {
+      expect(standardResult.value).toEqual(mainResult);
+    }
+  });
+});
+
+describe('Error message consistency tests', () => {
+  test('should produce identical error messages for string validations', async () => {
+    const schema = string().required().min(5).max(10).email();
+    const testValue = 'abc';
+
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    let mainAPIError: any;
+    try {
+      await schema.validate(testValue, { abortEarly: false });
+    } catch (err) {
+      mainAPIError = err;
+    }
+
+    expect(standardResult.issues?.map((issue) => issue.message).sort()).toEqual(
+      mainAPIError.inner.map((err: any) => err.message).sort(),
+    );
+  });
+
+  test('should produce identical error messages for number validations', async () => {
+    const schema = number().required().min(10).max(100).integer();
+    const testValue = 5.5;
+
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    let mainAPIError: any;
+    try {
+      await schema.validate(testValue, { abortEarly: false });
+    } catch (err) {
+      mainAPIError = err;
+    }
+
+    expect(standardResult.issues?.map((issue) => issue.message).sort()).toEqual(
+      mainAPIError.inner.map((err: any) => err.message).sort(),
+    );
+  });
+
+  test('should handle transform behavior consistently', async () => {
+    const schema = object({
+      name: string().trim().lowercase(),
+      age: number(),
+      active: bool(),
+    });
+
+    const testValue = {
+      name: '  JOHN DOE  ',
+      age: '25',
+      active: 'true',
+    };
+
+    // Test with standard schema
+    const standardResult = await schema['~standard'].validate(testValue);
+
+    // Test with main API
+    const mainResult = await schema.validate(testValue);
+
+    // Both should succeed and produce same transformed values
+    expect(standardResult.issues).toBeUndefined();
+    if (!standardResult.issues) {
+      expect(standardResult.value).toEqual(mainResult);
+      expect(standardResult.value).toEqual({
+        name: 'john doe',
+        age: 25,
+        active: true,
+      });
+    }
+  });
+});

--- a/test/standardSchema.ts
+++ b/test/standardSchema.ts
@@ -67,3 +67,39 @@ test('issues path is an array of property paths', async () => {
     { path: ['not.a.field'], message: '["not.a.field"] is a required field' },
   ]);
 });
+
+test('should clone correctly when using modifiers', async () => {
+  const schema = string().required();
+
+  const result = await schema['~standard'].validate('');
+
+  expect(result.issues).toEqual([
+    { path: undefined, message: 'this is a required field' },
+  ]);
+});
+
+test('should work correctly with lazy schemas', async () => {
+  let isNumber = false;
+  const schema = lazy(() => {
+    if (isNumber) {
+      return number().min(10);
+    }
+
+    return string().required().min(12);
+  });
+
+  const result = await schema['~standard'].validate('');
+
+  expect(result.issues).toEqual([
+    { path: undefined, message: 'this is a required field' },
+    { path: undefined, message: 'this must be at least 12 characters' },
+  ]);
+
+  isNumber = true;
+
+  const result2 = await schema['~standard'].validate(5);
+
+  expect(result2.issues).toEqual([
+    { path: undefined, message: 'this must be greater than or equal to 10' },
+  ]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,7 +2203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0-beta.3":
+"@standard-schema/spec@npm:^1.0.0-beta.4":
   version: 1.0.0-beta.4
   resolution: "@standard-schema/spec@npm:1.0.0-beta.4"
   checksum: 10c0/f001a08d798fe2eb19e4982fc7707549be2b5d0a61c6f144ace9c85e71eee23a2774d84f83f3b2dea02cb670cbe5cd91c151c0bebbc15d0b7fbcf6b29911e334
@@ -15124,7 +15124,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.22.5"
     "@rollup/plugin-babel": "npm:^5.3.1"
     "@rollup/plugin-node-resolve": "npm:^13.3.0"
-    "@standard-schema/spec": "npm:^1.0.0-beta.3"
+    "@standard-schema/spec": "npm:^1.0.0-beta.4"
     "@types/jest": "npm:^27.5.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
     "@typescript-eslint/parser": "npm:^5.62.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,10 +2203,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0-beta.4":
-  version: 1.0.0-beta.4
-  resolution: "@standard-schema/spec@npm:1.0.0-beta.4"
-  checksum: 10c0/f001a08d798fe2eb19e4982fc7707549be2b5d0a61c6f144ace9c85e71eee23a2774d84f83f3b2dea02cb670cbe5cd91c151c0bebbc15d0b7fbcf6b29911e334
+"@standard-schema/spec@npm:^1.0.0-rc.0":
+  version: 1.0.0-rc.0
+  resolution: "@standard-schema/spec@npm:1.0.0-rc.0"
+  checksum: 10c0/ddc5352a51704760717b91d27a5ea26724e0d36771cf3b8ac266b1ae930fe3cfb1159ad7b3cea157c3ca1e0c650aa15fd9e7b3f2540ae074c716a147a276d3f0
   languageName: node
   linkType: hard
 
@@ -15124,7 +15124,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.22.5"
     "@rollup/plugin-babel": "npm:^5.3.1"
     "@rollup/plugin-node-resolve": "npm:^13.3.0"
-    "@standard-schema/spec": "npm:^1.0.0-beta.4"
+    "@standard-schema/spec": "npm:^1.0.0-rc.0"
     "@types/jest": "npm:^27.5.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
     "@typescript-eslint/parser": "npm:^5.62.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,10 +2203,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0-rc.0":
-  version: 1.0.0-rc.0
-  resolution: "@standard-schema/spec@npm:1.0.0-rc.0"
-  checksum: 10c0/ddc5352a51704760717b91d27a5ea26724e0d36771cf3b8ac266b1ae930fe3cfb1159ad7b3cea157c3ca1e0c650aa15fd9e7b3f2540ae074c716a147a276d3f0
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@standard-schema/spec@npm:1.0.0"
+  checksum: 10c0/a1ab9a8bdc09b5b47aa8365d0e0ec40cc2df6437be02853696a0e377321653b0d3ac6f079a8c67d5ddbe9821025584b1fb71d9cc041a6666a96f1fadf2ece15f
   languageName: node
   linkType: hard
 
@@ -15124,7 +15124,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.22.5"
     "@rollup/plugin-babel": "npm:^5.3.1"
     "@rollup/plugin-node-resolve": "npm:^13.3.0"
-    "@standard-schema/spec": "npm:^1.0.0-rc.0"
+    "@standard-schema/spec": "npm:^1.0.0"
     "@types/jest": "npm:^27.5.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
     "@typescript-eslint/parser": "npm:^5.62.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2203,6 +2203,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@standard-schema/spec@npm:^1.0.0-beta.3":
+  version: 1.0.0-beta.4
+  resolution: "@standard-schema/spec@npm:1.0.0-beta.4"
+  checksum: 10c0/f001a08d798fe2eb19e4982fc7707549be2b5d0a61c6f144ace9c85e71eee23a2774d84f83f3b2dea02cb670cbe5cd91c151c0bebbc15d0b7fbcf6b29911e334
+  languageName: node
+  linkType: hard
+
 "@textlint/ast-node-types@npm:^12.1.1":
   version: 12.1.1
   resolution: "@textlint/ast-node-types@npm:12.1.1"
@@ -15117,6 +15124,7 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.22.5"
     "@rollup/plugin-babel": "npm:^5.3.1"
     "@rollup/plugin-node-resolve": "npm:^13.3.0"
+    "@standard-schema/spec": "npm:^1.0.0-beta.3"
     "@types/jest": "npm:^27.5.2"
     "@typescript-eslint/eslint-plugin": "npm:^5.62.0"
     "@typescript-eslint/parser": "npm:^5.62.0"


### PR DESCRIPTION
# What

This is a PR that implements the [standard schema interface](https://github.com/standard-schema/standard-schema) for yup.

**Motivation:** Standard schema is an initiative that is aimed to get all Typed schema providers to support a unified interface that will enable various tools and 3rd party libraries to seamlessly integrate with "a schema provider" which reduces friction when migrating from one provider to the other, and allows mixing these providers if one is suited for a task more than the rest. Another benefit is it allows 3rd party authors to ditch the "resolver" pattern which in turn reduces their users' friction.

We discussed this briefly in #2255 with no clear green light given on this, so I understand if this is something you don't want the burden of maintaining. I already did the work locally to play with it, since I was planning to build a yup standard schema adapter anyways. So, I thought I might as well just PR it.

I made sure to add tests and type tests as well, happy to address any issues in this PR.

# How

To avoid adding `@standard-schema/spec` as a dependency, I copied the types which is the [recommended approach](https://github.com/standard-schema/standard-schema#schema-library). I then make sure it is aligned with the spec by testing it against the spec which I added as a dev dependency.

I also had to implement a path splitter to make the paths compatible with the standard schema output.

#### Bundle size diff (~3%)

| Label | Size Before | Size After |
| --- | --- | --- |
| Bundle Size | 72.6 KB |  75.73 KB |
| Minified Size | 39.07 KB | 40.08 KB |
| Gzipped Size | 11.44 KB | 11.79 KB |

closes #2255 
