### PR TITLE
feat: update array validation messages for pluralization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ $RECYCLE.BIN/
 # Ignore build files
 lib/
 es/
+
+# Ignore JetBrains IDE files
+.idea

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -139,9 +139,12 @@ export let object: Required<ObjectLocale> = {
 };
 
 export let array: Required<ArrayLocale> = {
-  min: '${path} field must have at least ${min} items',
-  max: '${path} field must have less than or equal to ${max} items',
-  length: '${path} must have ${length} items',
+  min: ({ path, min }) =>
+    `${path} field must have at least ${min} item${!min || min === 1 ? '' : 's'}`,
+  max: ({ path, max }) =>
+    `${path} field must have less than or equal to ${max} item${!max || max === 1 ? '' : 's'}`,
+  length: ({ path, length }) =>
+    `${path} must have ${length} item${!length || length === 1 ? '' : 's'}`,
 };
 
 export let tuple: Required<TupleLocale> = {

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -140,11 +140,11 @@ export let object: Required<ObjectLocale> = {
 
 export let array: Required<ArrayLocale> = {
   min: ({ path, min }) =>
-    `${path} field must have at least ${min} item${!min || min === 1 ? '' : 's'}`,
+    `${path} field must have at least ${min} item${min === 1 ? '' : 's'}`,
   max: ({ path, max }) =>
-    `${path} field must have less than or equal to ${max} item${!max || max === 1 ? '' : 's'}`,
+    `${path} field must have less than or equal to ${max} item${max === 1 ? '' : 's'}`,
   length: ({ path, length }) =>
-    `${path} must have ${length} item${!length || length === 1 ? '' : 's'}`,
+    `${path} must have ${length} item${length === 1 ? '' : 's'}`,
 };
 
 export let tuple: Required<TupleLocale> = {

--- a/test/array.ts
+++ b/test/array.ts
@@ -112,6 +112,15 @@ describe('Array types', () => {
       expect(await array().min(10).min(4).isValid(Array(5).fill(0))).toBe(true);
     });
 
+    it('message should depend on the number provided (min, max, length)', () => {
+      expect(array().min(1).validate([])).rejects.toThrowError('this field must have at least 1 item');
+      expect(array().min(2).validate([])).rejects.toThrowError('this field must have at least 2 items');
+      expect(array().max(1).validate(Array(5).fill(0))).rejects.toThrowError('this field must have less than or equal to 1 item');
+      expect(array().max(2).validate(Array(5).fill(0))).rejects.toThrowError('this field must have less than or equal to 2 items');
+      expect(array().length(1).validate(Array(5).fill(0))).rejects.toThrowError('this must have 1 item');
+      expect(array().length(2).validate(Array(5).fill(0))).rejects.toThrowError('this must have 2 items');
+    });
+
     it('should respect subtype validations', async () => {
       let inst = array().of(number().max(5));
 


### PR DESCRIPTION
The default validation messages always showed "items" as plural for arrays validation even though the number was 0 or 1.
I've updated them to show "item" when the value is "1" and "items" otherwise.

"this field must have less than or equal to 1 items" becomes "this field must have less than or equal to 1 item"
"this field must have at least 1 items" becomes "this field must have at least 1 item"
"this must have 1 items" becomes "this must have 1 item"