### PR TITLE
fix: typefix the string.ensure() method

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -265,10 +265,10 @@ export default class StringSchema<
   }
 
   //-- transforms --
-  ensure(): StringSchema<NonNullable<TType>> {
-    return this.default('' as Defined<TType>).transform((val) =>
+  ensure() {
+    return this.default('' as Extract<"", TType>).transform((val) =>
       val === null ? '' : val,
-    ) as any;
+    );
   }
 
   trim(message = locale.trim) {


### PR DESCRIPTION
The `string.ensure()` method applies`.default('')`, however this information does not flow to typescript. This happens because the explicit return type of the method causes a loss of information about the transforms that happen within. The typing changes I have in this PR will ensure the type information flows through correctly.

Pragmatically, this issues effects the use of `Schema.getDefault()` method. Without this fix, any strings using `.ensure()` will have a type of `undefined`, but a runtime value of `""`.