### PR TITLE
Pass proper options to array casting.

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -81,11 +81,11 @@ export default class ArraySchema<
     const castArray = value.map((v, idx) => {
       const castElement = this.innerType!.cast(v, {
         ..._opts,
+        path: `${_opts.path || ''}[${idx}]`,
         parent: value,
         originalValue: v,
         value: v,
         index: idx,
-        path: `${_opts.path || ''}[${idx}]`,
 
       });
       

--- a/src/array.ts
+++ b/src/array.ts
@@ -81,8 +81,14 @@ export default class ArraySchema<
     const castArray = value.map((v, idx) => {
       const castElement = this.innerType!.cast(v, {
         ..._opts,
+        parent: value,
+        originalValue: v,
+        value: v,
+        index: idx,
         path: `${_opts.path || ''}[${idx}]`,
+
       });
+      
       if (castElement !== v) {
         isChanged = true;
       }

--- a/src/object.ts
+++ b/src/object.ts
@@ -181,10 +181,10 @@ export default class ObjectSchema<
     for (const prop of props) {
       let field = fields[prop];
       let exists = prop in (value as {})!;
+      let inputValue = value[prop];
 
       if (field) {
         let fieldValue;
-        let inputValue = value[prop];
 
         // safe to mutate since this is fired in sequence
         innerOptions.path = (options.path ? `${options.path}.` : '') + prop;
@@ -205,20 +205,19 @@ export default class ObjectSchema<
 
         fieldValue =
           !options.__validating || !strict
-            ? // TODO: use _cast, this is double resolving
-              (field as ISchema<any>).cast(value[prop], innerOptions)
-            : value[prop];
+            ? (field as ISchema<any>).cast(inputValue, innerOptions)
+            : inputValue;
 
         if (fieldValue !== undefined) {
           intermediateValue[prop] = fieldValue;
         }
       } else if (exists && !strip) {
-        intermediateValue[prop] = value[prop];
+        intermediateValue[prop] = inputValue;
       }
 
       if (
         exists !== prop in intermediateValue ||
-        intermediateValue[prop] !== value[prop]
+        intermediateValue[prop] !== inputValue
       ) {
         isChanged = true;
       }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -83,6 +83,10 @@ export interface CastOptions<C = {}> {
   stripUnknown?: boolean;
   // XXX: should be private?
   path?: string;
+  index?: number;
+  key?: string;
+  originalValue?: any;
+  value?: any;
   resolved?: boolean;
 }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -378,8 +378,8 @@ export default abstract class Schema<
     options: CastOptions<TContext> | CastOptionalityOptions<TContext> = {},
   ): this['__outputType'] {
     let resolvedSchema = this.resolve({
-      value,
       ...options,
+      value,
       // parent: options.parent,
       // context: options.context,
     });

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -114,6 +114,10 @@ export default class TupleSchema<
       const castElement = type.cast(value[idx], {
         ...options,
         path: `${options.path || ''}[${idx}]`,
+        parent: value,
+        originalValue: value[idx],
+        value: value[idx],
+        index: idx,
       });
       if (castElement !== value[idx]) isChanged = true;
       return castElement;

--- a/test/array.ts
+++ b/test/array.ts
@@ -214,6 +214,44 @@ describe('Array types', () => {
     await array().of(itemSchema).validate(value);
   });
 
+  it('should pass deeply resolved path to descendants', async () => {
+    let value = ['2', '3'];
+    let expectedPaths = ['items[0]', 'items[1]'];
+
+    let itemSchema = string().when([], function (_, _s, opts: any) {
+      let path = opts.path;
+      expect(expectedPaths).toContain(path);
+      return string().required();
+    });
+
+    const schema = object({
+      items: array().of(itemSchema)
+    })
+
+    await schema.validate({ items: value });
+  });
+
+  it('should pass array options to descendants when casting', async () => {
+    let value = ['1', '2'];
+
+    let itemSchema = string().when([], function (_, _s, opts: any) {
+
+      const parent = opts.parent;
+      const idx = opts.index;
+      const val = opts.value;
+      const originalValue = opts.originalValue;
+      
+      expect(parent).toEqual(value);
+      expect(typeof idx).toBe('number');
+      expect(val).toEqual(parent[idx]);
+      expect(originalValue).toEqual(parent[idx]);
+
+      return string();
+    });
+
+    await array().of(itemSchema).validate(value);
+  });
+
   it('should maintain array sparseness through validation', async () => {
     let sparseArray = new Array(2);
     sparseArray[1] = 1;

--- a/test/array.ts
+++ b/test/array.ts
@@ -29,6 +29,27 @@ describe('Array types', () => {
         'false',
       ]);
     });
+
+    it('should pass array options to descendants when casting', async () => {
+      let value = ['1', '2'];
+
+      let itemSchema = string().when([], function (_, _s, opts: any) {
+
+        const parent = opts.parent;
+        const idx = opts.index;
+        const val = opts.value;
+        const originalValue = opts.originalValue;
+        
+        expect(parent).toEqual(value);
+        expect(typeof idx).toBe('number');
+        expect(val).toEqual(parent[idx]);
+        expect(originalValue).toEqual(parent[idx]);
+
+        return string();
+      });
+
+      await array().of(itemSchema).validate(value);
+    });
   });
 
   it('should handle DEFAULT', () => {
@@ -229,27 +250,6 @@ describe('Array types', () => {
     })
 
     await schema.validate({ items: value });
-  });
-
-  it('should pass array options to descendants when casting', async () => {
-    let value = ['1', '2'];
-
-    let itemSchema = string().when([], function (_, _s, opts: any) {
-
-      const parent = opts.parent;
-      const idx = opts.index;
-      const val = opts.value;
-      const originalValue = opts.originalValue;
-      
-      expect(parent).toEqual(value);
-      expect(typeof idx).toBe('number');
-      expect(val).toEqual(parent[idx]);
-      expect(originalValue).toEqual(parent[idx]);
-
-      return string();
-    });
-
-    await array().of(itemSchema).validate(value);
   });
 
   it('should maintain array sparseness through validation', async () => {

--- a/test/tuple.ts
+++ b/test/tuple.ts
@@ -15,6 +15,27 @@ describe('Array types', () => {
         tuple([string(), string(), string()]).cast(['4', 5, false]),
       ).toEqual(['4', '5', 'false']);
     });
+
+    it('should pass array options to descendants when casting', async () => {
+      let value = ['1', '2'];
+  
+      let itemSchema = string().when([], function (_, _s, opts: any) {
+  
+        const parent = opts.parent;
+        const idx = opts.index;
+        const val = opts.value;
+        const originalValue = opts.originalValue;
+        
+        expect(parent).toEqual(value);
+        expect(typeof idx).toBe('number');
+        expect(val).toEqual(parent[idx]);
+        expect(originalValue).toEqual(parent[idx]);
+  
+        return string();
+      });
+
+      await tuple([itemSchema, itemSchema]).validate(value);
+    });
   });
 
   it('should handle DEFAULT', () => {


### PR DESCRIPTION
This PR aims to consolidate the options passed to arrays and tuples when casting/validating.

When validating tuples/arrays, yup passes `index`, `value`, `originalValue`, and `parent` to nested tests via `asNestedTest`. But when casting, these properties are either not passed down or passed down incorrectly. For example, `parent` currently is incorrect for nested casting. The `parent` should be the array that this item is inside.

This is particularly helpful when using `.when()` on inner types.

```js
const itemSchema = string().when([], (v, schema, textContext) => {
  // do something with the textContext.index
})

const arraySchema = array(itemSchema)

await arraySchema.validate(['Johnny', 'Cash'])
```

For objects, there is no functional change to the code. I removed a `TODO` comment and reused a variable for clarity. The `TODO` stated that casting the underlying field should use `_cast` because the field schema has already been resolved and using `cast` would cause double resolving. But I don't believe that is the case. The `field.resolve` returns a new schema with no `conditions`. So when calling `field.cast`, it does call `this.resolve` again but there are no conditions to resolve so its a noop.

Closes #2198 
May also close #2187 ?
