### PR TITLE
fix: checking whether the value checked for `.trim()`, `.lowercase()` and `.uppercase()` is a string

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -272,7 +272,7 @@ export default class StringSchema<
   }
 
   trim(message = locale.trim) {
-    return this.transform((val) => (val != null ? val.trim() : val)).test({
+    return this.transform((val) => (typeof val === 'string' ? val.trim() : val)).test({
       message,
       name: 'trim',
       test: isTrimmed,
@@ -281,7 +281,7 @@ export default class StringSchema<
 
   lowercase(message = locale.lowercase) {
     return this.transform((value) =>
-      !isAbsent(value) ? value.toLowerCase() : value,
+      typeof value === 'string' && !isAbsent(value) ? value.toLowerCase() : value,
     ).test({
       message,
       name: 'string_case',
@@ -294,7 +294,7 @@ export default class StringSchema<
 
   uppercase(message = locale.uppercase) {
     return this.transform((value) =>
-      !isAbsent(value) ? value.toUpperCase() : value,
+      typeof value === 'string' && !isAbsent(value) ? value.toUpperCase() : value,
     ).test({
       message,
       name: 'string_case',


### PR DESCRIPTION
The `.trim()`, `.lowercase()`, and `.uppercase()` methods do not check whether a value is a string. Therefore, the application crashes if the entered value is not a string.

I previously opened an [issue](https://github.com/jquense/yup/issues/2303) for this, but it didn't receive much attention. This is a critical issue, and I wanted to resolve it. 

### Everything here is as it should be ✅

<img width="1280" height="560" alt="473884983-eec50fd1-0c40-4f29-907c-b2f2d9eeeab8" src="https://github.com/user-attachments/assets/2e369cfd-2c05-4318-b3bb-a24db8b47105" />

### Everything here is as it should be ✅

<img width="1280" height="560" alt="473885038-97e1bc07-1e27-4670-8035-2bea4534ed62" src="https://github.com/user-attachments/assets/c3b07607-53b2-4ef2-8ab4-bd8f9d9e0e48" />

### But it wasn't supposed to be like this ❌

<img width="1280" height="698" alt="473885162-3333a75d-79ed-4cf9-b68d-45e20b781817" src="https://github.com/user-attachments/assets/01bc0c51-21f6-4583-bcfc-19dc79ad2573" />
