### PR TITLE
fix: keep generics on aliases of schema methods

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1030,10 +1030,10 @@ export default interface Schema<
     value: any,
     options?: ValidateOptions<TContext>,
   ): any;
-  equals: Schema['oneOf'];
-  is: Schema['oneOf'];
-  not: Schema['notOneOf'];
-  nope: Schema['notOneOf'];
+  equals: this['oneOf'];
+  is: this['oneOf'];
+  not: this['notOneOf'];
+  nope: this['notOneOf'];
 }
 
 // @ts-expect-error


### PR DESCRIPTION
Fix type inference for `equals`, `is`, `not`, and `nope` aliases by referencing `this['oneOf']` and `this['notOneOf']` instead of the base `Schema` type.

Previously, these aliases lost the implementing schema type context, causing `InferType` to resolve to `any` instead of the expected literal type.

```ts
const oneOf = Yup.string().oneOf(['example']).required();
type OneOf = InferType<typeof oneOf>; // "example"

const equals = Yup.string().equals(['example']).required();
type Equals = InferType<typeof equals>; // previously `any`, now "example"
```