### PR TITLE
Resolve lazy schema defaults

### DIFF
--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -117,6 +117,10 @@ class Lazy<T, TContext = AnyObject, TFlags extends Flags = any>
     return this._resolve(value, options).cast(value, options as any);
   }
 
+  getDefault(options?: ResolveOptions<TContext>): any {
+    return this._resolve(options?.value, options).getDefault(options);
+  }
+
   asNestedTest(config: NestedTestConfig) {
     let { key, index, parent, options } = config;
     let value = parent[index ?? key!];

--- a/test/object.ts
+++ b/test/object.ts
@@ -359,6 +359,14 @@ describe('Object types', () => {
       expect(objectWithConditions.getDefault()).toEqual({ child: 'not foo' });
     });
 
+    it('should resolve lazy field defaults', () => {
+      const objectWithLazyDefault = object({
+        child: lazy(() => number().default(1)),
+      });
+
+      expect(objectWithLazyDefault.getDefault()).toEqual({ child: 1 });
+    });
+
     it('should respect options when casting to default', () => {
       const objectWithConditions = object({
         child: string().when('$variable', {


### PR DESCRIPTION
Fixes #699.

## Summary
- add `getDefault()` forwarding on lazy schemas so default resolution uses the concrete schema returned by the lazy builder
- cover object default generation for a lazy field with its own default

## Verification
- `YARN_CACHE_FOLDER=/tmp/yup-699-yarn-cache corepack yarn vitest run test/object.ts -t "should resolve lazy field defaults"`
- `YARN_CACHE_FOLDER=/tmp/yup-699-yarn-cache corepack yarn vitest run test/object.ts test/lazy.ts`
- `YARN_CACHE_FOLDER=/tmp/yup-699-yarn-cache corepack yarn test`
- `YARN_CACHE_FOLDER=/tmp/yup-699-yarn-cache corepack yarn build:dts`
- `git diff --check`