### PR TITLE
fix: don't treat inherited Object.prototype keys (e.g. `constructor`) as object fields

### DIFF
--- a/src/object.ts
+++ b/src/object.ts
@@ -179,7 +179,13 @@ export default class ObjectSchema<
 
     let isChanged = false;
     for (const prop of props) {
-      let field = fields[prop];
+      // Only treat own properties as fields. A bare lookup walks the prototype
+      // chain, so an input key matching an inherited `Object.prototype` member
+      // (e.g. `constructor`, `hasOwnProperty`) resolves to that function and
+      // crashes downstream with "field.resolve is not a function".
+      let field = Object.prototype.hasOwnProperty.call(fields, prop)
+        ? fields[prop]
+        : undefined;
       let exists = prop in (value as {})!;
       let inputValue = value[prop];
 

--- a/test/object.ts
+++ b/test/object.ts
@@ -1182,4 +1182,28 @@ describe('Object types', () => {
       }),
     ).resolves.toEqual(false);
   });
+
+  describe('inherited Object.prototype keys (issue #660)', () => {
+    it('does not treat an undeclared `constructor` key as a field', async () => {
+      const schema = object().shape({});
+      // previously threw `TypeError: field.resolve is not a function`
+      await expect(schema.validate({ constructor: 'bar' })).resolves.toEqual({
+        constructor: 'bar',
+      });
+    });
+
+    it('does not treat other inherited keys as fields', async () => {
+      const schema = object().shape({});
+      await expect(
+        schema.validate({ hasOwnProperty: 'x', toString: 'y' }),
+      ).resolves.toEqual({ hasOwnProperty: 'x', toString: 'y' });
+    });
+
+    it('still validates a field explicitly named `constructor`', async () => {
+      const schema = object().shape({ constructor: number() });
+      await expect(schema.validate({ constructor: '5' })).resolves.toEqual({
+        constructor: 5,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #660.

### Problem

Casting/validating an object whose input contains a key that matches an inherited `Object.prototype` member crashes:

```js
object().shape({}).validate({ constructor: 'bar' });
// TypeError: field.resolve is not a function
```

It isn't limited to `constructor` — `hasOwnProperty`, `toString`, `valueOf`, etc. hit it too, whenever the schema doesn't declare an own field of that name.

### Cause

In `ObjectSchema._cast`, the per-key loop resolved the field with a bare property access:

```ts
let field = fields[prop];
```

That lookup walks the prototype chain. For an undeclared `constructor` key it returns `Object.prototype.constructor` (a function), so `if (field)` is truthy and the code then calls `field.resolve(...)` on a plain function — hence the throw. (The `Object.create(null)` init for `fields` is later undone by `clone()`'s `{ ...this.fields }` spread, which reintroduces `Object.prototype`.)

### Fix

Restrict the lookup to **own** properties so inherited keys fall through to the existing unknown-key handling (passthrough/strip), exactly like any other non-declared key:

```ts
let field = Object.prototype.hasOwnProperty.call(fields, prop)
  ? fields[prop]
  : undefined;
```

A field **explicitly declared** as `constructor` still resolves, validates, and casts as before.

### Tests

Added three cases to `test/object.ts`: an undeclared `constructor` key passes through instead of throwing, other inherited keys (`hasOwnProperty`, `toString`) pass through, and a declared `constructor: number()` field still validates/casts. Verified they fail on `master` (throw `field.resolve is not a function`) and pass with the fix. Full suite green (873 passing) and lint clean.

> Note: #455 and #1378 reference this issue but are 3.5+ years stale, in conflict, and #455 targets the long-removed `src/object.js`. This is a fresh, rebased, tested fix against current `master`.
