### PR TITLE
fix: validate array inner type against default when input is undefined

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -86,9 +86,8 @@ export default class ArraySchema<
         originalValue: v,
         value: v,
         index: idx,
-
       });
-      
+
       if (castElement !== v) {
         isChanged = true;
       }
@@ -131,7 +130,7 @@ export default class ArraySchema<
           index,
           parent: value,
           parentPath: options.path,
-          originalParent: options.originalValue ?? _value,
+          originalParent: originalValue,
         });
       }
 
@@ -139,7 +138,7 @@ export default class ArraySchema<
         {
           value,
           tests,
-          originalValue: options.originalValue ?? _value,
+          originalValue,
           options,
         },
         panic,

--- a/test/array.ts
+++ b/test/array.ts
@@ -35,27 +35,30 @@ describe('Array types', () => {
       let value = ['1', '2'];
 
       let itemSchema = string().when([], function (_, _s, opts: any) {
-
         const parent = opts.parent;
         const idx = opts.index;
         const val = opts.value;
         const originalValue = opts.originalValue;
-        
+
         expect(parent).toEqual(value);
         expect(typeof idx).toBe('number');
         expect(val).toEqual(parent[idx]);
         expect(originalValue).toEqual(parent[idx]);
 
-        return string().transform((value, _originalValue, _schema, options: any) => {
-          expect(parent).toEqual(options.parent);
-          expect(typeof options.index).toBe('number');
-          expect(val).toEqual(value);
+        return string().transform(
+          (value, _originalValue, _schema, options: any) => {
+            expect(parent).toEqual(options.parent);
+            expect(typeof options.index).toBe('number');
+            expect(val).toEqual(value);
 
-          return value;
-        });
+            return value;
+          },
+        );
       });
 
-      await array().of(itemSchema).validate(value, { context: { name: 'test'} });
+      await array()
+        .of(itemSchema)
+        .validate(value, { context: { name: 'test' } });
     });
   });
 
@@ -130,6 +133,29 @@ describe('Array types', () => {
       await expect(
         array().of(number().max(5)).isValid(undefined),
       ).resolves.toBe(true);
+    });
+
+    it('should validate the inner type against the default when input is undefined', async () => {
+      let inst = array().of(number().required()).default([1]);
+
+      expect(inst.validateSync(undefined)).toEqual([1]);
+      await expect(inst.validate(undefined)).resolves.toEqual([1]);
+      await expect(inst.isValid(undefined)).resolves.toBe(true);
+    });
+
+    it('should surface inner type errors for an invalid default', async () => {
+      let inst = array()
+        .of(number().required())
+        // @ts-expect-error testing an invalid default
+        .default([1, 'not a number', null]);
+
+      await expect(
+        inst.validate(undefined, { abortEarly: false }),
+      ).rejects.toEqual(
+        expect.objectContaining({
+          errors: expect.arrayContaining([expect.stringContaining('[2]')]),
+        }),
+      );
     });
 
     it('max should replace earlier tests', async () => {
@@ -253,8 +279,8 @@ describe('Array types', () => {
     });
 
     const schema = object({
-      items: array().of(itemSchema)
-    })
+      items: array().of(itemSchema),
+    });
 
     await schema.validate({ items: value });
   });


### PR DESCRIPTION
## Problem

When an `array()` schema has a `.default()` and is validated with `undefined`, validation throws a raw `TypeError` instead of validating/returning the default:

```js
array().of(number().required()).default([1]).validateSync(undefined);
// TypeError: Cannot read properties of undefined (reading '0')
```

The equivalent `object()` case works correctly, so this is an array-specific inconsistency.

Closes #2150

## Root cause

In `ArraySchema._validate`, when the `undefined` input is cast to the default array, the per-element nested tests were still seeded with `options.originalValue ?? _value` — which is the original `undefined` input. `asNestedTest` then does `originalValue: originalParent[index]`, i.e. `undefined[0]`, throwing the `TypeError`.

The method already computes a corrected local `originalValue` (`originalValue = originalValue || value`) that falls back to the cast value, but it wasn't being passed to the nested tests / `runTests`. `ObjectSchema._validate` does the right thing here and uses its local `originalValue`; this change brings array in line.

## Fix

Pass the already-computed local `originalValue` to both the nested tests and `runTests`, matching object-schema behavior. One-line change in two spots.

## Behavior after fix

- `array().of(number().required()).default([1]).validateSync(undefined)` → returns `[1]`
- An invalid default element now surfaces a proper `ValidationError` (e.g. `[1] must be a \`number\` type`) instead of a raw `TypeError`.

## Tests

Added two tests in `test/array.ts` (both fail before the change, pass after):
- validates the inner type against the default when input is `undefined` (sync, async, `isValid`)
- surfaces inner-type errors for an invalid default

Full suite passes (`yarn lint && vitest run`): 871 passing, no regressions.