### PR TITLE
fix: give lessThan and moreThan distinct exclusive test names

### DIFF
--- a/src/number.ts
+++ b/src/number.ts
@@ -91,7 +91,7 @@ export default class NumberSchema<
   lessThan(less: number | Reference<number>, message = locale.lessThan) {
     return this.test({
       message,
-      name: 'max',
+      name: 'lessThan',
       exclusive: true,
       params: { less },
       skipAbsent: true,
@@ -104,7 +104,7 @@ export default class NumberSchema<
   moreThan(more: number | Reference<number>, message = locale.moreThan) {
     return this.test({
       message,
-      name: 'min',
+      name: 'moreThan',
       exclusive: true,
       params: { more },
       skipAbsent: true,

--- a/test/number.ts
+++ b/test/number.ts
@@ -153,6 +153,26 @@ describe('Number types', function () {
     });
   });
 
+  it('should not override min when moreThan is chained after it', async () => {
+    // moreThan shares name 'min' with min (exclusive), so it replaces it —
+    // this test asserts the BUG is FIXED: both constraints must remain active.
+    const schema = number().min(5).moreThan(3);
+    // 4 > 3 (passes moreThan) but 4 < 5 (fails min) → must be invalid
+    await expect(schema.isValid(4)).resolves.toBe(false);
+    // 6 >= 5 and 6 > 3 → must be valid
+    await expect(schema.isValid(6)).resolves.toBe(true);
+  });
+
+  it('should not override max when lessThan is chained after it', async () => {
+    // lessThan shares name 'max' with max (exclusive), so it replaces it —
+    // this test asserts the BUG is FIXED: both constraints must remain active.
+    const schema = number().max(10).lessThan(15);
+    // 11 < 15 (passes lessThan) but 11 > 10 (fails max) → must be invalid
+    await expect(schema.isValid(11)).resolves.toBe(false);
+    // 9 <= 10 and 9 < 15 → must be valid
+    await expect(schema.isValid(9)).resolves.toBe(true);
+  });
+
   describe('integer', () => {
     let schema = number().integer();
 


### PR DESCRIPTION
## Bug

`number().min(5).moreThan(3)` silently drops the `min(5)` constraint. Because `moreThan()` registers its internal test under `name: 'min'` with `exclusive: true` — the same name used by `min()` — the later call replaces the earlier one. The mirror problem exists for `max()` and `lessThan()` (both used `name: 'max'`).

```js
// Before fix — silently drops min(5), only moreThan(3) enforced
number().min(5).moreThan(3).isValid(4) // → true (wrong, 4 < 5)

// Before fix — silently drops max(10), only lessThan(15) enforced
number().max(10).lessThan(15).isValid(11) // → true (wrong, 11 > 10)
```

## Fix

Rename the internal test in `lessThan()` to `'lessThan'` and in `moreThan()` to `'moreThan'`.

Chaining the **same** method still works (e.g. `lessThan(10).lessThan(14)` still replaces itself via `exclusive:true`), so all existing tests continue to pass. Chaining different methods (`min().moreThan()`, `max().lessThan()`) now correctly keeps both constraints active.

## Verification

```
yarn vitest run test/number.ts
```

**RED** (before fix): 4 tests fail — `number().min(5).moreThan(3).isValid(4)` returns `true` instead of `false`; `number().max(10).lessThan(15).isValid(11)` returns `true` instead of `false`.

**GREEN** (after fix): all 112 tests pass (56 async, 56 sync).

> AI-assisted contribution.