### PR TITLE
fix: sort errors correctly when object keys share a prefix

### DIFF
--- a/src/util/sortByKeyOrder.ts
+++ b/src/util/sortByKeyOrder.ts
@@ -3,7 +3,16 @@ import ValidationError from '../ValidationError';
 function findIndex(arr: readonly string[], err: ValidationError) {
   let idx = Infinity;
   arr.some((key, ii) => {
-    if (err.path?.includes(key)) {
+    const path = err.path;
+    // Match the key as a whole path segment rather than a substring, otherwise
+    // a key that is a prefix of another (e.g. `foo` vs `fooBar`) matches the
+    // wrong field and the errors sort incorrectly. See #2252.
+    if (
+      path != null &&
+      (path === key ||
+        path.startsWith(`${key}.`) ||
+        path.startsWith(`${key}[`))
+    ) {
       idx = ii;
       return true;
     }

--- a/test/object.ts
+++ b/test/object.ts
@@ -709,8 +709,8 @@ describe('Object types', () => {
     expect(error.inner).toMatchInlineSnapshot(`
       [
         [ValidationError: str is a required field],
-        [ValidationError: nest.innerStr is a required field],
         [ValidationError: nest.num must be greater than 5],
+        [ValidationError: nest.innerStr is a required field],
         [ValidationError: oops],
         [ValidationError: this must be a valid email],
         [ValidationError: this must be at least 3 characters],
@@ -719,8 +719,8 @@ describe('Object types', () => {
 
     expect(error.errors).toEqual([
       'str is a required field',
-      'nest.innerStr is a required field',
       'nest.num must be greater than 5',
+      'nest.innerStr is a required field',
       'oops',
       'this must be a valid email',
       'this must be at least 3 characters',
@@ -740,6 +740,26 @@ describe('Object types', () => {
       validationErrorWithMessages(
         'foo must be at least 5 characters',
         'bar is a required field',
+      ),
+    );
+  });
+
+  it('should sort errors by insertion order when keys share a prefix', async () => {
+    // `foo` is a substring of `fooBar`/`fooBiz`, which previously collided in
+    // the error sort and returned the errors out of order. See #2252.
+    let inst = object({
+      foo: string().required(),
+      fooBar: string().required(),
+      fooBiz: string().required(),
+    });
+
+    await expect(
+      inst.validate({ foo: '', fooBar: '', fooBiz: '' }, { abortEarly: false }),
+    ).rejects.toEqual(
+      validationErrorWithMessages(
+        'foo is a required field',
+        'fooBar is a required field',
+        'fooBiz is a required field',
       ),
     );
   });


### PR DESCRIPTION
Closes #2252.

## Problem

`sortByKeyOrder` (used to order an object's `abortEarly: false` errors by field declaration order) matches each key against the error path with a substring check:

```ts
if (err.path?.includes(key)) { ... }
```

When one key is a prefix of another, this matches the wrong field. For `object({ foo, fooBar, fooBiz })`, the error at path `fooBar` matches key `foo` (because `"fooBar".includes("foo")`), so `foo`, `fooBar` and `fooBiz` all resolve to index `0`. The comparator then returns `0` for every pair and the errors come back unsorted (in practice, reversed).

It also affects nested paths: `nest.innerStr` matches a top-level `str` key because `"nest.innerStr".includes("str")`.

As you noted on the issue and on #2281, the fix belongs in `findIndex` — it just needs to be smarter than a raw substring.

## Fix

Match the key as a whole **path segment** rather than a substring — the path either equals the key or continues with a `.` (nested object) or `[` (array index):

```ts
const path = err.path;
if (
  path != null &&
  (path === key || path.startsWith(`${key}.`) || path.startsWith(`${key}[`))
) { ... }
```

The change is contained to `src/util/sortByKeyOrder.ts` (no schema/API changes).

## Tests

Adds a regression test (`should sort errors by insertion order when keys share a prefix`) asserting that `object({ foo, fooBar, fooBiz })` returns its required-field errors in declaration order. It fails on the current code (errors come back reversed) and passes with this change.

One existing snapshot (`should flatten validation errors with abortEarly=false`) updates as a direct consequence of the fix: `nest.innerStr` previously matched the top-level `str` key by substring and sorted into the `str` group; it now correctly groups with the other `nest.*` errors. The within-`nest` order is unchanged by this fix (it reflects yup's existing error-collection order). The full suite (869 tests) passes; lint and `tsc` are clean.
