### PR TITLE
fix(number): truncate large values without 32-bit overflow

### DIFF
--- a/src/number.ts
+++ b/src/number.ts
@@ -132,7 +132,9 @@ export default class NumberSchema<
   }
 
   truncate() {
-    return this.transform((value) => (!isAbsent(value) ? value | 0 : value));
+    return this.transform((value) =>
+      !isAbsent(value) ? Math.trunc(value) : value,
+    );
   }
 
   round(method?: 'ceil' | 'floor' | 'round' | 'trunc') {

--- a/test/number.ts
+++ b/test/number.ts
@@ -44,6 +44,12 @@ describe('Number types', function () {
       expect(schema.truncate().cast(45.55)).toBe(45);
     });
 
+    it('should truncate values outside the 32-bit integer range', () => {
+      expect(schema.truncate().cast(3000000000.7)).toBe(3000000000);
+      expect(schema.truncate().cast(-3000000000.7)).toBe(-3000000000);
+      expect(schema.round('trunc').cast(3000000000.7)).toBe(3000000000);
+    });
+
     it('should return NaN for failed casts', () => {
       expect(number().cast('asfasf', { assert: false })).toEqual(NaN);
 


### PR DESCRIPTION
## Problem

`number().truncate()` corrupts any value outside the signed 32-bit range. The README describes `truncate()` as a transform that "coerces the value to an integer by stripping off the digits to the right of the decimal point", with no mention of a 32-bit limit, yet:

```js
number().truncate().cast(3000000000.7)      // returns -1294967296 (expected 3000000000)
number().truncate().cast(-3000000000.7)     // returns  1294967296 (expected -3000000000)
number().round('trunc').cast(3000000000.7)  // same, round('trunc') delegates to truncate()
```

## Root cause

`truncate()` uses a bitwise OR:

```js
return this.transform((value) => (!isAbsent(value) ? value | 0 : value));
```

`value | 0` runs the operand through `ToInt32`, which discards everything above bit 31 and wraps the result, so large magnitudes overflow into the wrong sign. The existing test only exercised `45.55`, which is in range, so the overflow was never caught.

`round('trunc')` calls `truncate()`, so it inherited the same defect. The sibling paths `round('floor')`, `round('ceil')` and `round('round')` already use `Math.floor`/`Math.ceil`/`Math.round` and are unaffected.

## Fix

Use `Math.trunc(value)`, which strips the fractional part with no range limit and brings `truncate()` in line with the other rounding methods:

```js
return this.transform((value) =>
  !isAbsent(value) ? Math.trunc(value) : value,
);
```

## Tests

Added a case to the existing `should truncate` block covering positive and negative out-of-32-bit-range values plus the `round('trunc')` delegation. The test fails on `master` (returns `-1294967296`) and passes with the fix. Full suite: 869 passed, 2 skipped.
