### PR TITLE
fix: expose `key`/`index` on test options for `validateAt`

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1042,14 +1042,24 @@ Schema.prototype.__isYupSchema__ = true;
 for (const method of ['validate', 'validateSync'])
   Schema.prototype[`${method}At` as 'validateAt' | 'validateSyncAt'] =
     function (path: string, value: any, options: ValidateOptions = {}) {
-      const { parent, parentPath, schema } = getIn(
+      const { parent, parentPath, parentPathIsArray, schema } = getIn(
         this,
         path,
         value,
         options.context,
       );
+      // Mirror the key/index that the normal validation path exposes on
+      // `testContext.options` for a field/array element (see `asNestedTest`),
+      // so tests behave the same whether reached via `validate` or `validateAt`.
+      const keyOptions =
+        parentPath === ''
+          ? {}
+          : parentPathIsArray
+            ? { index: parseInt(parentPath, 10) }
+            : { key: parentPath };
       return (schema as any)[method](parent && parent[parentPath], {
         ...options,
+        ...keyOptions,
         parent,
         path,
       });

--- a/src/util/reach.ts
+++ b/src/util/reach.ts
@@ -12,11 +12,14 @@ export function getIn<C = any>(
   schema: ISchema<any> | Reference<any>;
   parent: any;
   parentPath: string;
+  parentPathIsArray: boolean;
 } {
   let parent: any, lastPart: string, lastPartDebug: string;
+  let lastPartIsArray = false;
 
   // root path: ''
-  if (!path) return { parent, parentPath: path, schema };
+  if (!path)
+    return { parent, parentPath: path, parentPathIsArray: false, schema };
 
   forEach(path, (_part, isBracket, isArray) => {
     let part = isBracket ? _part.slice(1, _part.length - 1) : _part;
@@ -59,10 +62,16 @@ export function getIn<C = any>(
     }
 
     lastPart = part;
+    lastPartIsArray = isArray;
     lastPartDebug = isBracket ? '[' + _part + ']' : '.' + _part;
   });
 
-  return { schema, parent, parentPath: lastPart! };
+  return {
+    schema,
+    parent,
+    parentPath: lastPart!,
+    parentPathIsArray: lastPartIsArray,
+  };
 }
 
 function reach<P extends string, S extends ISchema<any>>(

--- a/test/mixed.ts
+++ b/test/mixed.ts
@@ -136,6 +136,44 @@ describe('Mixed Types ', () => {
     );
   });
 
+  it('validateAt should expose `key`/`index` on test options like validate', async () => {
+    let keyViaValidate: any;
+    let keyViaValidateAt: any;
+    let indexViaValidateAt: any;
+    let indexType: string | undefined;
+
+    const schema = object({
+      name: string().test('captures-key', '', function () {
+        keyViaValidate = this.options.key;
+        return true;
+      }),
+      list: array().of(
+        string().test('captures-index', '', function () {
+          indexViaValidateAt = this.options.index;
+          indexType = typeof this.options.index;
+          return true;
+        }),
+      ),
+    });
+
+    const value = { name: 'a', list: ['x', 'y'] };
+
+    // normal validation path exposes the field key on test options
+    await schema.validate(value);
+    expect(keyViaValidate).toBe('name');
+
+    // validateAt should expose the same key for the targeted field
+    keyViaValidate = undefined;
+    await schema.validateAt('name', value);
+    keyViaValidateAt = keyViaValidate;
+    expect(keyViaValidateAt).toBe('name');
+
+    // array element paths expose a numeric `index` (matching validate)
+    await schema.validateAt('list[1]', value);
+    expect(indexViaValidateAt).toBe(1);
+    expect(indexType).toBe('number');
+  });
+
   // xit('should castAt', async () => {
   //   const schema = object({
   //     foo: array().of(


### PR DESCRIPTION
Fixes #2270.

`validateAt` / `validateSyncAt` re-root the schema and call `validate` directly, but never forwarded the targeted path's leaf segment as the test option `key` (or `index` for array elements). The normal validation path sets these via `asNestedTest`, so the asymmetry was observable:

```js
const schema = object({
  name: string().test('t', '', (v, ctx) => ctx.options.key !== undefined),
});
await schema.validate({ name: 'a' });          // ctx.options.key === 'name'  ✅
await schema.validateAt('name', { name: 'a' }); // ctx.options.key === undefined ❌
```

`getIn` now also reports whether the leaf segment is an array index, so `validateAt` mirrors what `validate` exposes: a string `key` for object fields and a numeric `index` for array elements. Root path (`''`) is left untouched (no key, like root `validate`).

Added a regression test in `test/mixed.ts` (verified failing before the fix). Full suite + eslint + tsc green.