### PR TITLE
docs: fix date section link to extending schema types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1474,7 +1474,7 @@ await schema.isValid(true); // => true
 ### date
 
 Define a Date schema. By default ISO date strings will parse correctly,
-for more robust parsing options see the extending schema types at the end of the readme.
+for more robust parsing options see [Extending built-in schema with new methods](#extending-built-in-schema-with-new-methods).
 Inherits from [`Schema`](#Schema).
 
 ```js


### PR DESCRIPTION
## Summary
- The `date` docs said to see extending schema types "at the end of the readme", but that section is under TypeScript integration and was easy to miss.
- Point the sentence at [Extending built-in schema with new methods](#extending-built-in-schema-with-new-methods) instead.

Fixes #1791

## Test plan
- [ ] Open README `date` section and confirm the link jumps to the extending schema section
- [ ] Confirm no other README wording changes