### PR TITLE
fix(date): pad short fractional seconds in ISO parse

### DIFF
--- a/src/util/parseIsoDate.ts
+++ b/src/util/parseIsoDate.ts
@@ -59,7 +59,7 @@ export function parseDateStruct(date: string) {
     second: toNumber(regexResult[6]),
     millisecond: regexResult[7]
       ? // allow arbitrary sub-second precision beyond milliseconds
-        toNumber(regexResult[7].substring(0, 3))
+        toNumber(regexResult[7].substring(0, 3).padEnd(3, '0'))
       : 0,
     precision: regexResult[7]?.length ?? undefined,
     z: regexResult[8] || undefined,

--- a/test/date.ts
+++ b/test/date.ts
@@ -25,6 +25,31 @@ describe('Date types', () => {
     expect(inst.cast(null, { assert: false })).toEqual(null);
   });
 
+  it('should parse sub-3-digit fractional seconds', () => {
+    let inst = date();
+
+    // `.5` is 500ms, not 5ms (ISO 8601 / native Date)
+    expect(inst.cast('2020-01-01T00:00:00.5Z')).toEqual(
+      new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 500)),
+    );
+    expect(inst.cast('2020-01-01T00:00:00.12Z')).toEqual(
+      new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 120)),
+    );
+    expect(inst.cast('2020-01-01T00:00:00.05Z')).toEqual(
+      new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 50)),
+    );
+    expect(inst.cast('2020-01-01T00:00:00.1Z')).toEqual(
+      new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 100)),
+    );
+    // 3+ digits keep existing first-three-digits behavior
+    expect(inst.cast('2020-01-01T00:00:00.500Z')).toEqual(
+      new Date(Date.UTC(2020, 0, 1, 0, 0, 0, 500)),
+    );
+    expect(inst.cast('2016-08-10T11:32:19.2125Z')).toEqual(
+      new Date(1470828739212),
+    );
+  });
+
   it('should return invalid date for failed non-null casts', function () {
     let inst = date();
 


### PR DESCRIPTION
Closes #2339

`parseIsoDate` converted the first three fractional-second digits as an integer without right-padding, so `.5Z` became 5ms instead of 500ms and `.12Z` became 12ms instead of 120ms.

Pad the captured fraction to three digits before converting. Existing 3+ digit cases (`.500`, `.1234`) still use the first three digits.
