### PR TITLE
Right-pad sub-3-digit fractional seconds when parsing ISO dates

### DIFF
--- a/src/util/parseIsoDate.ts
+++ b/src/util/parseIsoDate.ts
@@ -58,8 +58,10 @@ export function parseDateStruct(date: string) {
     minute: toNumber(regexResult[5]),
     second: toNumber(regexResult[6]),
     millisecond: regexResult[7]
-      ? // allow arbitrary sub-second precision beyond milliseconds
-        toNumber(regexResult[7].substring(0, 3))
+      ? // allow arbitrary sub-second precision beyond milliseconds, and
+        // right-pad fractions shorter than 3 digits so e.g. ".5" reads as
+        // 500ms rather than 5ms
+        toNumber(regexResult[7].substring(0, 3).padEnd(3, '0'))
       : 0,
     precision: regexResult[7]?.length ?? undefined,
     z: regexResult[8] || undefined,

--- a/test/util/parseIsoDate.ts
+++ b/test/util/parseIsoDate.ts
@@ -125,6 +125,30 @@ describe('date-time', () => {
       const expected = Date.UTC(2001, 1, 3, 4, 5, 6, 7);
       expect(result).toBe(expected);
     });
+
+    describe('fractional seconds shorter than 3 digits', () => {
+      // a fraction shorter than 3 digits must be right-padded with zeros
+      // before being read as milliseconds, matching the native ISO 8601
+      // parser (`new Date` / `Date.parse`), e.g. ".5" -> 500ms, not 5ms
+      test('2001-02-03T04:05:06.5Z', () => {
+        const result = parseIsoDate('2001-02-03T04:05:06.5Z');
+        const expected = Date.UTC(2001, 1, 3, 4, 5, 6, 500);
+        expect(result).toBe(expected);
+        expect(result).toBe(Date.parse('2001-02-03T04:05:06.5Z'));
+      });
+      test('2001-02-03T04:05:06.05Z', () => {
+        const result = parseIsoDate('2001-02-03T04:05:06.05Z');
+        const expected = Date.UTC(2001, 1, 3, 4, 5, 6, 50);
+        expect(result).toBe(expected);
+        expect(result).toBe(Date.parse('2001-02-03T04:05:06.05Z'));
+      });
+      test('2001-02-03T04:05:06.12Z', () => {
+        const result = parseIsoDate('2001-02-03T04:05:06.12Z');
+        const expected = Date.UTC(2001, 1, 3, 4, 5, 6, 120);
+        expect(result).toBe(expected);
+        expect(result).toBe(Date.parse('2001-02-03T04:05:06.12Z'));
+      });
+    });
   });
 
   describe('offset time zone', () => {


### PR DESCRIPTION
## Summary

Fixes #2339.

```js
import { date } from 'yup';

date().cast('2020-01-01T00:00:00.5Z').toISOString();
// actual:   "2020-01-01T00:00:00.005Z"
// expected: "2020-01-01T00:00:00.500Z"   (matches new Date('2020-01-01T00:00:00.5Z'))
```

`parseDateStruct()` in `src/util/parseIsoDate.ts` truncates the fractional-seconds capture group to its first 3 characters and reads that directly as milliseconds:

```ts
toNumber(regexResult[7].substring(0, 3))
```

For a 3+ digit fraction this is a correct truncation (`.123` → `123`), but for anything shorter it's wrong, because the substring is read as a literal integer rather than a fraction: `.5` → `5` instead of `500`, `.05` → `5` instead of `50`, `.12` → `12` instead of `120`.

## Fix

Right-pad the truncated fraction with zeros before parsing it as a number (`.substring(0, 3).padEnd(3, '0')`), matching the native ISO 8601 parser (`new Date` / `Date.parse`) that this file's own header says it enhances. This doesn't change behavior for 3+ digit fractions, which `padEnd` leaves untouched.

(This is distinct from #60, which fixed the leading-zero case for exactly-3-digit fractions like `.012`; that case was already correct and stays correct here.)

## Test plan

- Added a `fractional seconds shorter than 3 digits` block in `test/util/parseIsoDate.ts` covering `.5`, `.05`, and `.12`, each asserted against both the expected `Date.UTC(...)` value and `Date.parse(...)` directly.
- Verified the regression: reverting the source change turns all 3 new tests from passing into failing with exactly the wrong values from the issue (5ms instead of 500ms, 5ms instead of 50ms, 12ms instead of 120ms).
- Full suite passes: `yarn vitest run` — 873 passing, 2 pre-existing skipped.
- `yarn lint` passes.