### PR TITLE
fix: pad sub-3-digit fractional seconds when parsing ISO dates

### DIFF
--- a/src/util/parseIsoDate.ts
+++ b/src/util/parseIsoDate.ts
@@ -58,8 +58,10 @@ export function parseDateStruct(date: string) {
     minute: toNumber(regexResult[5]),
     second: toNumber(regexResult[6]),
     millisecond: regexResult[7]
-      ? // allow arbitrary sub-second precision beyond milliseconds
-        toNumber(regexResult[7].substring(0, 3))
+      ? // allow arbitrary sub-second precision beyond milliseconds, and pad to
+        // exactly 3 digits so a shorter fraction keeps its magnitude
+        // (".5" is 500ms, not 5ms)
+        toNumber(regexResult[7].substring(0, 3).padEnd(3, '0'))
       : 0,
     precision: regexResult[7]?.length ?? undefined,
     z: regexResult[8] || undefined,

--- a/test/util/parseIsoDate.ts
+++ b/test/util/parseIsoDate.ts
@@ -125,6 +125,25 @@ describe('date-time', () => {
       const expected = Date.UTC(2001, 1, 3, 4, 5, 6, 7);
       expect(result).toBe(expected);
     });
+
+    // Fractional seconds shorter than 3 digits denote tenths/hundredths, so
+    // ".5" is 500ms, not 5ms. They must match the native ISO 8601 parser.
+    describe('sub-3-digit fractional seconds', () => {
+      test.each([
+        ['2001-02-03T04:05:06.5Z', 500],
+        ['2001-02-03T04:05:06.05Z', 50],
+        ['2001-02-03T04:05:06.1Z', 100],
+        ['2001-02-03T04:05:06.12Z', 120],
+        // exactly 3 digits and truncation of extra precision stay correct
+        ['2001-02-03T04:05:06.123Z', 123],
+        ['2001-02-03T04:05:06.1239Z', 123],
+      ])('%s -> %ims', (input, ms) => {
+        const expected = Date.UTC(2001, 1, 3, 4, 5, 6, ms);
+        expect(parseIsoDate(input)).toBe(expected);
+        // parity with the native parser
+        expect(parseIsoDate(input)).toBe(new Date(input).valueOf());
+      });
+    });
   });
 
   describe('offset time zone', () => {


### PR DESCRIPTION
## Bug

Closes #2339.

`date().cast()` (and `parseIsoDate`) mis-parses ISO datetimes whose fractional-seconds part has fewer than 3 digits. A leading `.5` means **500 ms**, but yup reads it as **5 ms** — silently wrong by up to 495 ms.

```js
import { date } from 'yup';

date().cast('2020-01-01T00:00:00.5Z').toISOString();
// actual:   "2020-01-01T00:00:00.005Z"
// expected: "2020-01-01T00:00:00.500Z"   (same as new Date('2020-01-01T00:00:00.5Z'))
```

| input   | yup (before) | native `Date` |
|---------|--------------|---------------|
| `.1Z`   | 1 ms         | 100 ms        |
| `.05Z`  | 5 ms         | 50 ms         |
| `.12Z`  | 12 ms        | 120 ms        |
| `.5Z`   | 5 ms         | 500 ms        |
| `.123Z` | 123 ms       | 123 ms (ok)   |

## Cause

In `src/util/parseIsoDate.ts` the milliseconds field truncates to 3 fractional digits but never right-pads, so a fraction shorter than 3 digits is parsed as a literal integer:

```ts
toNumber(regexResult[7].substring(0, 3))  // ".5" -> "5" -> 5, should be 500
```

## Fix

Right-pad the (already truncated) fraction to exactly 3 digits before converting:

```ts
toNumber(regexResult[7].substring(0, 3).padEnd(3, '0'))  // ".5" -> "500" -> 500
```

Exactly-3-digit fractions and truncation of extra precision are unchanged (`.123` → 123, `.1239` → 123), so this only affects the previously-wrong sub-3-digit cases and brings them in line with the native ISO 8601 parser that this file enhances.

(Distinct from the merged #60, which fixed the 3-digit leading-zero case `.012`→120; sub-3-digit fractions remained wrong.)

## Tests

Added a `sub-3-digit fractional seconds` block in `test/util/parseIsoDate.ts` asserting `.5/.05/.1/.12` map to 500/50/100/120 ms and match `new Date(...)`, plus the 3-digit and truncation cases stay correct. Full suite passes (`879 passed`).
